### PR TITLE
avoid extra download with env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - export EARTHIO_TEST_ENV=earth-env-test
   # Path to example data downloaded.  Dont put it in earthio dir
   - export ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
-  - if [ "$IGNORE_ELM_DATA_DOWNLOAD" = "" ]; then mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*;fi
+  - mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*
   # Build the env
   - MAKE_MINICONDA=1 . build_earthio_env.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - export EARTHIO_TEST_ENV=earth-env-test
   # Path to example data downloaded.  Dont put it in earthio dir
   - export ELM_EXAMPLE_DATA_PATH=/tmp/elm-data
-  - mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*
+  - if [ "$IGNORE_ELM_DATA_DOWNLOAD" = "" ]; then mkdir -p $ELM_EXAMPLE_DATA_PATH; rm -rf $ELM_EXAMPLE_DATA_PATH/*;fi
   # Build the env
   - MAKE_MINICONDA=1 . build_earthio_env.sh
 

--- a/build_earthio_env.sh
+++ b/build_earthio_env.sh
@@ -38,7 +38,9 @@ build_earthio_env(){
         export ELM_EXAMPLE_DATA_PATH="${EARTHIO_BUILD_DIR}/../elm-data";
     fi
     conda install -c defaults -c conda-forge requests pbzip2 python-magic six  || return 1; # for download_test_data.py
-    mkdir -p $ELM_EXAMPLE_DATA_PATH && cd $ELM_EXAMPLE_DATA_PATH && python "${EARTHIO_BUILD_DIR}/scripts/download_test_data.py" || return 1;
+    if [ "$IGNORE_ELM_DATA_DOWNLOAD" = "" ];then
+        mkdir -p $ELM_EXAMPLE_DATA_PATH && cd $ELM_EXAMPLE_DATA_PATH && python "${EARTHIO_BUILD_DIR}/scripts/download_test_data.py" || return 1;
+    fi
     cd $EARTHIO_BUILD_DIR || return 1;
 }
 build_earthio_env && source activate ${EARTHIO_TEST_ENV} && echo OK


### PR DESCRIPTION
Setting environment variable `IGNORE_ELM_DATA_DOWNLOAD` to anything other than "" will ignore the `download_data.py` script that downloads test NetCDF, HDF 4/ 5, and GeoTiff files.