### PR TITLE
fix deploy section of .travis to not hardcode conda-build version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ notifications:
 deploy:
   - provider: script
     script:
-      - conda install --name root anaconda-client python=3.5 conda-build==2.0.4 && conda build $EARTHIO_CHANNEL_STR --output --python $PYTHON --numpy $NUMPY conda.recipe | xargs conda convert -p all -o _pkgs && find _pkgs -type f -name "*.tar.bz2" -exec anaconda -t $ANACONDA_UPLOAD_TOKEN upload --user $ANACONDA_UPLOAD_USER --label dev {} \+
+      - conda install --name root anaconda-client && conda build $EARTHIO_CHANNEL_STR --output --python $PYTHON --numpy $NUMPY conda.recipe | xargs conda convert -p all -o _pkgs && find _pkgs -type f -name "*.tar.bz2" -exec anaconda -t $ANACONDA_UPLOAD_TOKEN upload --user $ANACONDA_UPLOAD_USER --label dev {} \+
     on:
       tags: false
       all_branches: true


### PR DESCRIPTION
Title says it: conda-build version was hard coded a while back to avoid a problem version from being installed.  