### PR TITLE
Move elm.sample_util to earthio.filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,9 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# elm data
+[0-9]*
+netcdf
+tif
+hdf[45]

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 script:
   - cd $EARTHIO_BUILD_DIR
   - . activate $EARTHIO_TEST_ENV
+  - conda install -f -c conda-forge gdal # Workaround for install issue
   - py.test -m 'not slow and not requires_elm' -v earthio/tests
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
 script:
   - cd $EARTHIO_BUILD_DIR
   - . activate $EARTHIO_TEST_ENV
-  - conda install -f -c conda-forge gdal # Workaround for install issue
   - py.test -m 'not slow and not requires_elm' -v earthio/tests
   - rm -rf $ELM_EXAMPLE_DATA_PATH/*
 

--- a/build_earthio_env.sh
+++ b/build_earthio_env.sh
@@ -8,9 +8,7 @@ export ELM_EXAMPLE_DATA_PATH="${ELM_EXAMPLE_DATA_PATH:-${EARTHIO_BUILD_DIR}/../e
 export PYTHON=${PYTHON:-3.5}
 export NUMPY=${NUMPY:-1.11}
 
-set -e
-
-if [ -n "$MAKE_MINICONDA" ];then
+if [ -n "$MAKE_MINICONDA" ]; then
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     bash miniconda.sh -b -f -p $HOME/miniconda
     export PATH="$HOME/miniconda/bin:$PATH"
@@ -20,7 +18,7 @@ conda config --set always_yes true
 conda install --name root 'conda-build<=3'
 conda env remove --name ${EARTHIO_TEST_ENV} &> /dev/null
 
-if [ "x$EARTHIO_INSTALL_METHOD" = "xgit" ];then
+if [ "$EARTHIO_INSTALL_METHOD" = "git" ]; then
     conda env create -n ${EARTHIO_TEST_ENV} -f environment.yml
     source activate ${EARTHIO_TEST_ENV}
     python setup.py develop
@@ -30,14 +28,10 @@ else
     source activate ${EARTHIO_TEST_ENV}
 fi
 
-if [ "x$IGNORE_ELM_DATA_DOWNLOAD" = "x" ];then
+if [ -z "$IGNORE_ELM_DATA_DOWNLOAD" ]; then
     conda install -c defaults -c conda-forge requests pbzip2 python-magic
     mkdir -p $ELM_EXAMPLE_DATA_PATH
-    df -h
-    pushd $ELM_EXAMPLE_DATA_PATH && python "${EARTHIO_BUILD_DIR}/scripts/download_test_data.py" --files hdf4.tar.bz2 tif.tar.bz2  && popd
-    df -h
+    pushd $ELM_EXAMPLE_DATA_PATH && python "$EARTHIO_BUILD_DIR/scripts/download_test_data.py" --files hdf4.tar.bz2 tif.tar.bz2 && popd
 fi
-
-set +e
 
 source activate ${EARTHIO_TEST_ENV} && echo OK

--- a/build_earthio_env.sh
+++ b/build_earthio_env.sh
@@ -1,45 +1,43 @@
 source deactivate;
 
 export EARTHIO_BUILD_DIR=`pwd -P`
-export EARTHIO_CHANNEL_STR="${EARTHIO_CHANNEL_STR:- -c ioam -c conda-forge -c scitools/label/dev }"
+export EARTHIO_CHANNEL_STR="${EARTHIO_CHANNEL_STR:- -c ioam -c conda-forge -c scitools/label/dev -c elm }"
 export EARTHIO_TEST_ENV="${EARTHIO_TEST_ENV:-earth-env-test}"
 export EARTHIO_INSTALL_METHOD="${EARTHIO_INSTALL_METHOD:-conda}"
 export ELM_EXAMPLE_DATA_PATH="${ELM_EXAMPLE_DATA_PATH:-${EARTHIO_BUILD_DIR}/../elm-data}";
 export PYTHON=${PYTHON:-3.5}
 export NUMPY=${NUMPY:-1.11}
 
-build_earthio_env() {
-    set -e
+set -e
 
-    if [ -n "$MAKE_MINICONDA" ];then
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-        bash miniconda.sh -b -p $HOME/miniconda
-        export PATH="$HOME/miniconda/bin:$PATH"
-    fi
+if [ -n "$MAKE_MINICONDA" ];then
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    bash miniconda.sh -b -f -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"
+fi
 
-    conda config --set always_yes true;
-    conda install --name root conda conda-build;
-    conda env remove --name ${EARTHIO_TEST_ENV} &> /dev/null;
+conda config --set always_yes true
+conda install --name root conda conda-build
+conda env remove --name ${EARTHIO_TEST_ENV} &> /dev/null
 
-    if [ "x$EARTHIO_INSTALL_METHOD" = "xgit" ];then
-        conda env create -n ${EARTHIO_TEST_ENV} -f environment.yml
-        source activate ${EARTHIO_TEST_ENV}
-        python setup.py develop
-    else
-        conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
-        conda create --use-local --name $EARTHIO_TEST_ENV $EARTHIO_CHANNEL_STR python=$PYTHON numpy=$NUMPY earthio
-        source activate ${EARTHIO_TEST_ENV}
-    fi
+if [ "x$EARTHIO_INSTALL_METHOD" = "xgit" ];then
+    conda env create -n ${EARTHIO_TEST_ENV} -f environment.yml
+    source activate ${EARTHIO_TEST_ENV}
+    python setup.py develop
+else
+    conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
+    conda create --use-local --name $EARTHIO_TEST_ENV $EARTHIO_CHANNEL_STR python=$PYTHON numpy=$NUMPY earthio
+    source activate ${EARTHIO_TEST_ENV}
+fi
 
-    if [ "x$IGNORE_ELM_DATA_DOWNLOAD" = "x" ];then
-        conda install -c defaults -c conda-forge requests pbzip2 python-magic
-        mkdir -p $ELM_EXAMPLE_DATA_PATH
-        df -h
-        pushd $ELM_EXAMPLE_DATA_PATH && python "${EARTHIO_BUILD_DIR}/scripts/download_test_data.py" --files hdf4.tar.bz2 tif.tar.bz2  && popd
-        df -h
-    fi
+if [ "x$IGNORE_ELM_DATA_DOWNLOAD" = "x" ];then
+    conda install -c defaults -c conda-forge requests pbzip2 python-magic
+    mkdir -p $ELM_EXAMPLE_DATA_PATH
+    df -h
+    pushd $ELM_EXAMPLE_DATA_PATH && python "${EARTHIO_BUILD_DIR}/scripts/download_test_data.py" --files hdf4.tar.bz2 tif.tar.bz2  && popd
+    df -h
+fi
 
-    set +e
-}
+set +e
 
-build_earthio_env && source activate ${EARTHIO_TEST_ENV} && echo OK
+source activate ${EARTHIO_TEST_ENV} && echo OK

--- a/build_earthio_env.sh
+++ b/build_earthio_env.sh
@@ -21,9 +21,11 @@ conda install --name root conda conda-build
 conda env remove --name ${EARTHIO_TEST_ENV} &> /dev/null
 
 if [ "x$EARTHIO_INSTALL_METHOD" = "xgit" ];then
+    set +e
     conda env create -n ${EARTHIO_TEST_ENV} -f environment.yml
     source activate ${EARTHIO_TEST_ENV}
     python setup.py develop
+    set -e
 else
     conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
     conda create --use-local --name $EARTHIO_TEST_ENV $EARTHIO_CHANNEL_STR python=$PYTHON numpy=$NUMPY earthio

--- a/build_earthio_env.sh
+++ b/build_earthio_env.sh
@@ -1,7 +1,7 @@
 source deactivate;
 
 export EARTHIO_BUILD_DIR=`pwd -P`
-export EARTHIO_CHANNEL_STR="${EARTHIO_CHANNEL_STR:- -c ioam -c conda-forge -c scitools/label/dev -c elm }"
+export EARTHIO_CHANNEL_STR="${EARTHIO_CHANNEL_STR:- -c ioam -c conda-forge -c scitools/label/dev }"
 export EARTHIO_TEST_ENV="${EARTHIO_TEST_ENV:-earth-env-test}"
 export EARTHIO_INSTALL_METHOD="${EARTHIO_INSTALL_METHOD:-conda}"
 export ELM_EXAMPLE_DATA_PATH="${ELM_EXAMPLE_DATA_PATH:-${EARTHIO_BUILD_DIR}/../elm-data}";
@@ -17,15 +17,13 @@ if [ -n "$MAKE_MINICONDA" ];then
 fi
 
 conda config --set always_yes true
-conda install --name root conda conda-build
+conda install --name root 'conda-build<=3'
 conda env remove --name ${EARTHIO_TEST_ENV} &> /dev/null
 
 if [ "x$EARTHIO_INSTALL_METHOD" = "xgit" ];then
-    set +e
     conda env create -n ${EARTHIO_TEST_ENV} -f environment.yml
     source activate ${EARTHIO_TEST_ENV}
     python setup.py develop
-    set -e
 else
     conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
     conda create --use-local --name $EARTHIO_TEST_ENV $EARTHIO_CHANNEL_STR python=$PYTHON numpy=$NUMPY earthio

--- a/build_earthio_env.sh
+++ b/build_earthio_env.sh
@@ -18,14 +18,13 @@ conda config --set always_yes true
 conda install --name root 'conda-build<=3'
 conda env remove --name ${EARTHIO_TEST_ENV} &> /dev/null
 
+conda env create -n ${EARTHIO_TEST_ENV} -f environment.yml
+source activate ${EARTHIO_TEST_ENV}
+conda install -f -c conda-forge gdal # Workaround for gdal install issue
 if [ "$EARTHIO_INSTALL_METHOD" = "git" ]; then
-    conda env create -n ${EARTHIO_TEST_ENV} -f environment.yml
-    source activate ${EARTHIO_TEST_ENV}
-    python setup.py develop
+    python setup.py develop --no-deps
 else
     conda build $EARTHIO_CHANNEL_STR --python $PYTHON --numpy $NUMPY conda.recipe
-    conda create --use-local --name $EARTHIO_TEST_ENV $EARTHIO_CHANNEL_STR python=$PYTHON numpy=$NUMPY earthio
-    source activate ${EARTHIO_TEST_ENV}
 fi
 
 if [ -z "$IGNORE_ELM_DATA_DOWNLOAD" ]; then

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,7 +41,6 @@ extra:
     - ioam
     - conda-forge
     - scitools/label/dev
-    - elm
 
   maintainers:
     - Peter Steinberg - Continuum Analytics - psteinberg [at] continuum [dot] io
@@ -53,4 +52,3 @@ test:
 
   requires:
     - pytest
-    - elm

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -53,4 +53,3 @@ test:
 
   requires:
     - pytest
-    - elm # Only needed for tests

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -53,3 +53,4 @@ test:
 
   requires:
     - pytest
+    - elm

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -14,44 +14,35 @@ requirements:
     - setuptools
 
   run:
-    - attrs
-    - bokeh
-    - cartopy
-    - colorcet
-    - dask
-    - datashader
+    - deap
     - dill
-    - geoviews
-    - holoviews
+    - gdal
     - iris
-    - jupyter
-    - krb5
-    - matplotlib
-    - networkx
-    - numba
-    - numpy
-    - pandas
-    - paramnb
-    - pyproj
     - pytables
-    - pytest
-    - python
     - python-magic
-    - rasterio ==1.0a8
-    - requests
-    - scipy
-    - shapely
+    - rasterio
+    - scikit-image
+    - scikit-learn
     - statsmodels
-    - tblib
-    - xarray
-    - yaml
-    - six
+    - colorcet
+    - datashader
+    - geoviews
+    - paramnb
+    - jupyter
 
 about:
   home: http://github.com/ContinuumIO/elm
   license: MIT
 
 extra:
+  channels:
+    - defaults
+    - gbrener
+    - ioam
+    - conda-forge
+    - scitools/label/dev
+    - elm
+
   maintainers:
     - Peter Steinberg - Continuum Analytics - psteinberg [at] continuum [dot] io
     - Greg Brener - Continuum Analytics - gbrener [at] continuum [dot] io
@@ -59,3 +50,7 @@ extra:
 test:
   imports:
     - earthio
+
+  requires:
+    - pytest
+    - elm # Only needed for tests

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -25,4 +25,3 @@ from shapely import *
 from statsmodels import *
 from xarray import *
 import yaml
-import elm.config.tests.fixtures

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -25,3 +25,4 @@ from shapely import *
 from statsmodels import *
 from xarray import *
 import yaml
+import elm.config.tests.fixtures, elm.pipeline, elm.pipeline.tests.util

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -25,4 +25,4 @@ from shapely import *
 from statsmodels import *
 from xarray import *
 import yaml
-import elm.config.tests.fixtures, elm.pipeline, elm.pipeline.tests.util
+import elm.config.tests.fixtures

--- a/earthio/__init__.py
+++ b/earthio/__init__.py
@@ -9,3 +9,4 @@ from earthio.util import *
 from earthio.reshape import *
 from earthio.load_array import *
 from earthio.local_file_iterators import *
+from earthio.filters import *

--- a/earthio/elm_store.py
+++ b/earthio/elm_store.py
@@ -196,7 +196,7 @@ class ElmStore(xr.Dataset):
         Returns:
             :(arr, fig): where arr is the 3-D numpy array and fig is the figure
         '''
-        from elm.sample_util.plotting_helpers import plot_3d
+        from earthio.filters.plotting_helpers import plot_3d
         return plot_3d(self, bands, title, scale, axis_labels, **imshow_kwargs)
 
     def __str__(self):

--- a/earthio/filters/band_selection.py
+++ b/earthio/filters/band_selection.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+----------------------------------
+
+``earthio.filters.band_selection``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+from collections import OrderedDict
+
+from gdalconst import GA_ReadOnly
+import gdal
+import logging
+
+from .config import import_callable
+from .config.func_signatures import get_args_kwargs_defaults
+
+logger = logging.getLogger(__name__)
+
+def _filename_filter(filename, search=None, func=None):
+    '''Filter filenames based on search pattern or function'''
+    if search is None and func is None:
+        return True
+    if search is not None:
+        keep = re.search(search, filename)
+    else:
+        keep = True
+    if func is None:
+        return keep
+    return func(filename) and keep
+
+
+
+def select_from_file(*sampler_args, **kwargs):
+    '''select_from_file is the typical sampler used in the elm config
+    file interface system via elm.pipeline.parse_run_config
+
+    Parameters:
+        :sampler_args: tuple of one element - a filename
+        :band_specs: list of band_specs included in a data_source. default: None
+        :metadata_filter: ignored. default: None
+        :filename_search: a search token for a filenames. default: None
+        :filename_filter: a function that returns True/False to keep filename. default: None
+        :dry_run:  if True, don't actually read file, just return True if accepted. default: False
+        :load_meta: Function, typically from earthio, to load metadata. default: None
+        :load_array: Function, typically from earthio, to load ElmStore. default: None
+        :kwargs: (additional) may contain "reader" such as "hdf4", "tif", "hdf5", "netcdf"
+
+    '''
+    kwargs = dict(
+        band_specs=None,
+        metadata_filter=None,
+        filename_filter=None,
+        filename_search=None,
+        dry_run=False,
+        load_meta=None,
+        load_array=None,
+    ).update(kwargs)
+    filename = sampler_args[0]
+    keep_file = _filename_filter(filename,
+                                 search=filename_search,
+                                 func=filename_filter)
+    logger.debug('Filename {} keep_file {}'.format(filename, keep_file))
+    args_required, default_kwargs, var_keywords = get_args_kwargs_defaults(load_meta)
+    if dry_run:
+        return True
+    sample = load_array(filename, band_specs=band_specs, reader=kwargs.get('reader', None))
+    return sample

--- a/earthio/filters/band_selection.py
+++ b/earthio/filters/band_selection.py
@@ -13,8 +13,8 @@ from gdalconst import GA_ReadOnly
 import gdal
 import logging
 
-from .config import import_callable
-from .config.func_signatures import get_args_kwargs_defaults
+from earthio.filters.config import import_callable
+from earthio.filters.config.func_signatures import get_args_kwargs_defaults
 
 logger = logging.getLogger(__name__)
 

--- a/earthio/filters/band_selection.py
+++ b/earthio/filters/band_selection.py
@@ -13,7 +13,6 @@ from gdalconst import GA_ReadOnly
 import gdal
 import logging
 
-from earthio.filters.config import import_callable
 from earthio.filters.config.func_signatures import get_args_kwargs_defaults
 
 logger = logging.getLogger(__name__)

--- a/earthio/filters/bands_operation.py
+++ b/earthio/filters/bands_operation.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from functools import partial
 
 import xarray as xr
-from .change_coords import ModifySample
-from ..elm_store import ElmStore
+from earthio.filters.change_coords import ModifySample
+from earthio.elm_store import ElmStore
 
 from six import PY2
 

--- a/earthio/filters/bands_operation.py
+++ b/earthio/filters/bands_operation.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from functools import partial
+
+import xarray as xr
+from .change_coords import ModifySample
+from ..elm_store import ElmStore
+
+from six import PY2
+
+def two_bands_operation(method, X, y=None, sample_weight=None, spec=None, **kwargs):
+    if PY2:
+        bands = X.band_order[:]
+    else:
+        bands = X.band_order.copy()
+    es = {}
+    if not spec:
+        raise ValueError('Expected "spec" in kwargs, e.g. {"ndvi": ["band_4", "band_3]}')
+    for idx, (key, (b1, b2)) in enumerate(sorted(spec.items())):
+        band1 = getattr(X, b1)
+        band2 = getattr(X, b2)
+        if method == 'normed_diff':
+            new = (band1 - band2) / (band1 + band2)
+        elif method == 'diff':
+            new = band1 - band2
+        elif method == 'sum':
+            new = band1 + band2
+        elif method == 'ratio':
+            new = band1 / band2
+        new.attrs.update(band1.attrs)
+        es[key] = new
+        bands.append(key)
+    Xnew = ElmStore(xr.merge([ElmStore(es, add_canvas=False), X]), add_canvas=False)
+    xattrs_copy = X.attrs.copy()
+    Xnew.attrs.update(xattrs_copy)
+    Xnew.attrs['band_order'] = bands
+    return (Xnew, y, sample_weight)
+
+
+bands_normed_diff = partial(two_bands_operation, 'normed_diff')
+bands_diff = partial(two_bands_operation, 'diff')
+bands_sum = partial(two_bands_operation, 'sum')
+bands_ratio = partial(two_bands_operation, 'ratio')
+
+NormedBandsDiff = partial(ModifySample, func=bands_normed_diff)
+BandsDiff = partial(ModifySample, func=bands_diff)
+BandsSum = partial(ModifySample, func=bands_sum)
+BandsRatio = partial(ModifySample, func=bands_ratio)
+
+__all__ = ['NormedBandsDiff',
+           'BandsDiff',
+           'BandsSum',
+           'BandsRatio']

--- a/earthio/filters/change_coords.py
+++ b/earthio/filters/change_coords.py
@@ -7,19 +7,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 '''
-from ..reshape import (select_canvas as _select_canvas,
-                       drop_na_rows as _drop_na_rows,
-                       ElmStore,
-                       flatten as _flatten,
-                       inverse_flatten as _inverse_flatten,
-                       Canvas,
-                       check_is_flat,
-                       transpose as _transpose,
-                       aggregate_simple)
+from earthio.reshape import (select_canvas as _select_canvas,
+                             drop_na_rows as _drop_na_rows,
+                             ElmStore,
+                             flatten as _flatten,
+                             inverse_flatten as _inverse_flatten,
+                             Canvas,
+                             check_is_flat,
+                             transpose as _transpose,
+                             aggregate_simple)
 
 import numpy as np
 
-from .step_mixin import StepMixin
+from earthio.filters.step_mixin import StepMixin
 
 CHANGE_COORDS_ACTIONS = (
     'select_canvas',
@@ -257,7 +257,7 @@ class ModifySample(StepMixin):
         self.kwargs = kwargs
 
     def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
-        from .sample_pipeline import _split_pipeline_output
+        from earthio.filters.sample_pipeline import _split_pipeline_output
         kw = dict(y=y, sample_weight=sample_weight, **kwargs)
         kw.update(self.kwargs)
         output = self.func(X, **kw)

--- a/earthio/filters/change_coords.py
+++ b/earthio/filters/change_coords.py
@@ -1,0 +1,287 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+---------------------------------
+
+``earthio.filters.change_coords``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+from ..reshape import (select_canvas as _select_canvas,
+                       drop_na_rows as _drop_na_rows,
+                       ElmStore,
+                       flatten as _flatten,
+                       inverse_flatten as _inverse_flatten,
+                       Canvas,
+                       check_is_flat,
+                       transpose as _transpose,
+                       aggregate_simple)
+
+import numpy as np
+
+from .step_mixin import StepMixin
+
+CHANGE_COORDS_ACTIONS = (
+    'select_canvas',
+    'flatten',
+    'drop_na_rows',
+    'inverse_flatten',
+    'modify_sample',
+    'transpose',
+    'agg',
+)
+
+
+class SelectCanvas(StepMixin):
+    '''Reindex all bands (DataArrays) to the coordinates of band given
+
+    Parameters:
+        :band:  a string name of a DataArray in the ElmStore's data_vars
+
+    See also:
+        :func:`earthio.select_canvas`
+        :mod:`earthio.reshape`
+    '''
+    _sp_step = 'select_canvas'
+    def __init__(self, band=None):
+        self.band = band
+
+    def get_params(self):
+        '''Returns the band'''
+        return {'band': self.band}
+
+    def set_params(self, **params):
+        if not params or (params and 'band' not in params):
+            raise ValueError('Only "band" is a valid parameter to SelectCanvas')
+        self.band = params['band']
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        band_arr = getattr(X, self.band, None)
+        if band_arr is None:
+            raise ValueError('Argument to select_canvas should be a band name, e.g. "band_1" (found {} but bands are {})'.format(band, X.data_vars))
+        new_canvas = band_arr.canvas
+        X = _select_canvas(X, new_canvas)
+        return (X, y, sample_weight)
+
+    transform = fit = fit_transform
+
+    @classmethod
+    def from_config_dict(cls, **kwargs):
+        return cls(kwargs['select_canvas'])
+
+class Flatten(StepMixin):
+    '''
+    flatten an ElmStore from rasters in separate DataArrays to
+    single flat DataArray
+
+    See also:
+        :class:`earthio.flatten`
+        :mod:`earthio.reshape`
+    '''
+    _sp_step = 'flatten'
+
+    def __init__(self):
+        pass
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        return (_flatten(X), y, sample_weight)
+
+    transform = fit = fit_transform
+
+    def get_params(self):
+        return {}
+
+    def set_params(self, **params):
+        if params:
+            raise ValueError("Flatten takes no arguments")
+    @classmethod
+    def from_config_dict(cls, **kwargs):
+        return cls()
+
+class DropNaRows(StepMixin):
+    '''In an ElmStore that has a DataArray flat, drop NA rows
+
+    See Also:
+        :class:`earthio.drop_na_rows`
+        :mod:`earthio.reshape`
+    '''
+    _sp_step = 'drop_na_rows'
+    def __init__(self):
+        '''In an ElmStore that has a DataArray flat, drop NA rows
+
+        See also:
+            :class:`earthio.drop_na_rows`
+            :mod:`earthio.reshape`
+        '''
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        check_is_flat(X)
+        if y is not None:
+            if y.size != np.prod(y.shape) or y.size != X.flat.values.shape[0]:
+                msg = 'Found y size ({}) != X.flat.values.shape[0] ({})'
+                raise ValueError(msg.format(y.size, X.flat.values.shape[0]))
+        Xnew = _drop_na_rows(X)
+        if y is not None:
+            y = y[Xnew.flat.space.values]
+        if sample_weight is not None:
+            sample_weight = sample_weight[Xnew.space.values]
+        return (Xnew, y, sample_weight)
+
+    transform = fit = fit_transform
+
+    def get_params(self):
+        return {}
+
+    def set_params(self, **params):
+        if params:
+            raise ValueError('DropNaRows takes no parameters')
+
+    @classmethod
+    def from_config_dict(cls, **kwargs):
+        return cls()
+
+class InverseFlatten(StepMixin):
+    _sp_step = 'inverse_flatten'
+    def __init__(self):
+        '''Convert a flattened ElmStore back to separate bands
+        See also:
+            :func:`earthio.inverse_flatten`
+            :mod:`earthio.reshape`
+        '''
+
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        return (_inverse_flatten(X), y, sample_weight)
+
+    transform = fit = fit_transform
+
+    def get_params(self):
+        return {}
+
+    def set_params(self, **params):
+        if params:
+            raise ValueError('DropNaRows takes no parameters')
+
+    @classmethod
+    def from_config_dict(cls, **kwargs):
+        return cls()
+
+class Transpose(StepMixin):
+    _sp_step = 'transpose'
+    def __init__(self, trans_arg):
+        '''Calls the xarray.DataArray.transpose method
+
+        Parameters:
+            :trans_arg: Passed to xarray.DataArray.transpose
+
+        See also:
+            :func:`earthio.transpose`
+            :mod:`earthio.reshape`
+
+        '''
+        self.trans_arg = trans_arg
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        return (_transpose(X, self.trans_arg), y, sample_weight)
+
+    transform = fit = fit_transform
+
+    def get_params(self):
+        return {'trans_arg': self.trans_arg}
+
+    def set_params(self, **params):
+        if params and not 'trans_arg' in params:
+            raise ValueError('Transpose set_params takes only "trans_arg" - argument to xarray transpose')
+
+    @classmethod
+    def from_config_dict(cls, **kwargs):
+        return cls(kwargs['transpose'])
+
+class Agg(StepMixin):
+    _sp_step = 'agg'
+    def __init__(self, func=None, axis=None, dim=None):
+        '''Aggregate along a dim or axis using func
+
+        Parameters:
+            :func: aggregation function word like "mean", "std"
+            :axis: integer axis argument
+            :dim:  dimension name for aggregation
+
+        See also:
+            :func:`earthio.aggregate_simple`
+            :mod:`earthio.reshape`
+
+        '''
+        self.axis = axis
+        self.dim = dim
+        if dim is None and axis is None:
+            raise ValueError('Expected dim or axis in keyword __init__ args')
+        if not func:
+            raise ValueError('Expected "func" in keyword arguments to Agg')
+        self.func = func
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        X = aggregate_simple(X, axis=self.axis, dim=self.dim,
+                             func=self.func)
+        return (X, y, sample_weight)
+
+    transform = fit = fit_transform
+
+    def get_params(self):
+        return {'axis': self.axis, 'dim': self.dim, 'func': self.func}
+
+    def set_params(self, **params):
+        if not 'axis' in params and not 'dim' in params and not 'func' in params:
+            raise ValueError('Agg requires "dim", "axis", or "func" keywords')
+
+    @classmethod
+    def from_config_dict(cls, **kwargs):
+        return cls(**kwargs['agg'])
+
+
+class ModifySample(StepMixin):
+    _sp_step = 'modify_sample'
+    def __init__(self, func, **kwargs):
+        '''Call func with kwargs on a step of a Pipeline
+
+        Parameters:
+            :func: function with the signature ``func(X, y=None, sample_weight=None, **kwargs)``
+            :kwargs: keyword arguments passed to func
+
+        See also:
+            :func:`earthio.modify_sample`
+            :mod:`earthio.reshape`
+
+        '''
+        self.func = func
+        self.kwargs = kwargs
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        from .sample_pipeline import _split_pipeline_output
+        kw = dict(y=y, sample_weight=sample_weight, **kwargs)
+        kw.update(self.kwargs)
+        output = self.func(X, **kw)
+        return _split_pipeline_output(output, X, y, sample_weight, 'ModifySample')
+
+    transform = fit = fit_transform
+
+    def get_params(self):
+        return dict(func=self.func, **self.kwargs)
+
+    def set_params(self, **params):
+        if 'func' in params:
+            self.func = params['func']
+        self.kwargs.update({k: v for k, v in params.items() if k != 'func'})
+
+    @classmethod
+    def from_config_dict(cls, **kwargs):
+        kw = dict(kwargs)
+        func = kw.pop('modify_sample')
+        return cls(func, **kw)
+
+
+gs = tuple(globals().items())
+__all__ = []
+for k,v in gs:
+    if isinstance(v, type) and issubclass(v, StepMixin):
+        __all__.append(k)

--- a/earthio/filters/config/__init__.py
+++ b/earthio/filters/config/__init__.py
@@ -1,0 +1,1 @@
+from earthio.filters.config.func_signatures import *

--- a/earthio/filters/config/func_signatures.py
+++ b/earthio/filters/config/func_signatures.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+----------------------------
+
+``elm.config.func_signatures``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+import inspect
+import sys
+
+def get_args_kwargs_defaults(func):
+    '''Get the required args, defaults, and var keywords of func
+
+    Parameters:
+        :func: callable
+    Returns:
+        :(args, kwargs, takes_var_keywords): where args are names /
+        of required args, kwargs are keyword args with defaults, and
+        takes_var_keywords indicates whether func has a \*\*param
+     '''
+    if hasattr(inspect, 'signature'):
+        sig = inspect.signature(func) # Python 3
+        empty = inspect._empty
+    else:
+        import funcsigs
+        sig = funcsigs.signature(func) # Python 2
+        empty = funcsigs._empty
+    params = sig.parameters
+    kwargs = {}
+    args = []
+    takes_variable_keywords = None
+    for k, v in params.items():
+        if v.default != empty:
+            kwargs[k] = v.default
+        else:
+            args.append(k)
+        if v.kind == 4:
+            #<_ParameterKind.VAR_KEYWORD: 4>
+            takes_variable_keywords = k
+
+        '''sig = inspect.getargpsec(func) # Python 2
+        args = sig.args
+        kwargs = sig.keywords
+        called = None
+        for x in range(100):
+            test_args = (func,) + tuple(range(x))
+            try:
+                called = inspect.getcallargs(*test_args)
+                break
+            except:
+                pass
+        if called is None:
+            raise
+        '''
+    return args, kwargs, takes_variable_keywords
+
+def filter_kwargs_to_func(func, **kwargs):
+    '''Remove keys/values from kwargs if cannot be passed to func'''
+    arg_spec, kwarg_spec, takes_variable_keywords = get_args_kwargs_defaults(func)
+    new = {}
+    for k,v in kwargs.items():
+        if k in kwarg_spec:
+            new[k] = v
+    if takes_variable_keywords:
+        new[takes_variable_keywords] = {k: v for k,v in kwargs.items()
+                                        if not k in new}
+    return new
+
+__all__ = ['get_args_kwargs_defaults', 'filter_kwargs_to_func']

--- a/earthio/filters/make_blobs.py
+++ b/earthio/filters/make_blobs.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import OrderedDict
 
-from ..elm_store import ElmStore
+from earthio.elm_store import ElmStore
 from earthio import xy_canvas
 import numpy as np
 import xarray as xr
 from sklearn.datasets import make_blobs
 
-from .config import filter_kwargs_to_func
+from earthio.filters.config import filter_kwargs_to_func
 
 
 BANDS = ['band_{}'.format(idx + 1) for idx in range(40)]

--- a/earthio/filters/make_blobs.py
+++ b/earthio/filters/make_blobs.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import OrderedDict
+
+from ..elm_store import ElmStore
+from earthio import xy_canvas
+import numpy as np
+import xarray as xr
+from sklearn.datasets import make_blobs
+
+from .config import filter_kwargs_to_func
+
+
+BANDS = ['band_{}'.format(idx + 1) for idx in range(40)]
+GEO = [-2223901.039333, 926.6254330549998, 0.0, 8895604.157333, 0.0, -926.6254330549995]
+
+def random_elm_store(bands=None, centers=None, std_devs=None, height=100, width=80, **kwargs):
+    print('Enter with', bands, centers, std_devs, height, width)
+    if isinstance(bands, int):
+        bands = ['band_{}'.format(idx + 1) for idx in range(bands)]
+    if centers is not None:
+        centers = np.array(centers)
+    lenn = centers.shape[1] if centers is not None else 3 if not bands else len(bands)
+    bands = bands or ['band_{}'.format(idx + 1) for idx in range(lenn)]
+    if centers is None:
+        centers = np.arange(100, 100 + lenn * len(bands)).reshape((lenn, len(bands)))
+    if std_devs is None:
+        std_devs = np.ones((len(centers), len(bands)))
+    if kwargs.get('attrs'):
+        attrs = kwargs['attrs']
+    else:
+        attrs = {'width': width,
+                 'height': height,
+                 'geo_transform': GEO,
+                 'canvas': xy_canvas(GEO, width, height, ('y', 'x'))}
+    es_dict = OrderedDict()
+    print('SHAPES', width, height, len(bands), centers, std_devs)
+    arr, y = make_blobs(n_samples=width * height, n_features=len(bands),
+                        centers=centers, cluster_std=std_devs)
+    for idx, band in enumerate(bands):
+        es_dict[band] = xr.DataArray(arr[:, idx].reshape((height, width)),
+                                     coords=[('y', np.arange(height)),
+                                             ('x', np.arange(width))],
+                                     dims=('y', 'x'),
+                                     attrs=attrs)
+    attrs['band_order'] = bands
+    X = ElmStore(es_dict, attrs=attrs)
+    if kwargs.get('return_y'):
+        return X, y
+    return X
+
+
+def make_blobs_elm_store(**make_blobs_kwargs):
+    '''sklearn.datasets.make_blobs - but return ElmStore
+    Parameters:
+        as_2d_or_3d:       int - 2 or 3 for num dimensions
+        make_blobs_kwargs: kwargs for make_blobs, such as:
+                           n_samples=100,
+                           n_features=2,
+                           centers=3,
+                           cluster_std=1.0,
+                           center_box=(-10.0, 10.0),
+                           shuffle=True,
+                           random_state=None'''
+    kwargs = filter_kwargs_to_func(make_blobs, **make_blobs_kwargs)
+    arr  = make_blobs(**kwargs)[0]
+    band = ['band_{}'.format(idx) for idx in range(arr.shape[1])]
+    es = ElmStore({'flat': xr.DataArray(arr,
+                  coords=[('space', np.arange(arr.shape[0])),
+                          ('band', band)],
+                  dims=['space', 'band'],
+                  attrs={'make_blobs': make_blobs_kwargs})})
+    return es
+

--- a/earthio/filters/plotting_helpers.py
+++ b/earthio/filters/plotting_helpers.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+------------------------------------
+
+``earthio.filters.plotting_helpers``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+from collections import Sequence
+import matplotlib.pyplot as plt
+import numpy as np
+
+def plot_3d(X, bands, title='', scale=None, axis_labels=True,
+            **imshow_kwargs):
+    '''Plot a true or pseudo color image of 3 bands
+
+    Parameters:
+        :X: ElmStore or xarray.Dataset
+        :bands: list of 3 band names that are in X
+        :title: title for figure
+        :scale: divide all values by this (e.g. 2\*\* 16 for uint16)
+        :axis_labels: True / False show axis_labels
+        :\*\*imshow_kwargs: passed to imshow
+
+    Returns:
+        :(arr, fig): where arr is the 3-D numpy array and fig is the figure
+
+    '''
+    arr = None
+    scale = 1 if scale is None else scale
+    for idx, band in enumerate(bands):
+        val = getattr(X, band).values
+        if idx == 0:
+            arr = np.empty((val.shape) + (len(bands),), dtype=np.float32)
+        if isinstance(scale, Sequence):
+            s = scale[idx]
+        else:
+            s = scale
+        arr[:, :, idx] = val.astype(np.float64) / s
+    plt.imshow(arr, **imshow_kwargs)
+    plt.title('{:^100}'.format(title))
+    fig = plt.gcf()
+    if not axis_labels:
+        fig.axes[0].get_xaxis().set_visible(False)
+        fig.axes[0].get_yaxis().set_visible(False)
+    return (arr, fig)

--- a/earthio/filters/polygon_tools.py
+++ b/earthio/filters/polygon_tools.py
@@ -1,0 +1,212 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+---------------------------------
+
+``earthio.filters.polygon_tools``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+import numpy as np
+from numba import njit
+from matplotlib.path import Path
+import matplotlib.patches as patches
+import matplotlib.pyplot as plt
+
+# Implementation inspired by pseudo-code and pros at:
+# http://www.inf.usi.ch/hormann/papers/Hormann.2001.TPI.pdf
+# These are essentially winding algorithms with a variety of shortcuts
+# A bounding box is also employed as an initial filter.
+# If a set of polygons overlap then once a point is included it is not
+# rechecked for its presence in future polygons.
+
+
+@njit
+def close_poly(vx, vy):
+    """
+    Returns a closed form of coordinates of a polygon.
+    (Essentially tack the first coordinate to the end of the list of
+    coordinates to close the shape).
+
+    Parameters:
+        :vx: The x coordinates of the polygon (in drawing order)
+        :vy: The y coordinates of the polygon (in drawing order)
+
+    Returns:
+        :tuple(X, Y): where X and Y correspond to closed versions of vx and vy respectively.
+    """
+    Px = np.empty(vx.size + 1)
+    Px[:-1] = vx
+    Px[-1] = vx[0]
+    Py = np.empty(vy.size + 1)
+    Py[:-1] = vy
+    Py[-1] = vy[0]
+    return (Px, Py)
+
+
+@njit
+def point_in_poly(x, y, vx, vy, inon=True, closedPoly=False):
+    """
+    Point in poly determines if a point is in a polygon.
+
+    Parameters:
+        :x: The x coordinate of the point
+        :y: The y coordinate of the point
+        :vx: The x coordinates of the polygon (in drawing order)
+        :vy: The y coordinates of the polygon (in drawing order)
+        :inon: If True consider points on edges and vertices as inside the polygon
+        :closedPoly: If True the polygon is closed in the [vx, vy] coordinate definitions
+
+    Returns:
+        :nonzero: if the point is in the polygon
+    """
+    if not closedPoly:
+        (Px, Py) = close_poly(vx, vy)
+    else:
+        Px = vx
+        Py = vy
+
+    w = 0
+    vlty = Py < y
+    vxmx = Px - x
+    vymy = Py - y
+    for idx in range(len(Px) - 1):
+
+        if Py[idx + 1] == y:
+            if Px[idx + 1] == x:
+                return inon  # vertex
+            else:
+                if Py[idx] == y and ((Px[idx + 1] > x) == (Px[idx] < x)):
+                    return inon  # edge
+
+        if vlty[idx] != vlty[idx + 1]:
+            if Px[idx] >= x:
+                if Px[idx + 1] > x:
+                    z = (Py[idx + 1] > Py[idx])
+                    w = w + 2 * z - 1
+                else:
+                    d = (vxmx[idx] * vymy[idx + 1] - vxmx[idx + 1] * vymy[idx])
+                    if d == 0:
+                        return inon  # edge
+                    z = (Py[idx + 1] > Py[idx])
+                    if (d > 0) == z:
+                        w = w + 2 * z - 1
+            else:
+                if Px[idx + 1] > x:
+                    d = (vxmx[idx] * vymy[idx + 1] - vxmx[idx + 1] * vymy[idx])
+                    if d == 0:
+                        return inon  # edge
+                    z = (Py[idx + 1] > Py[idx])
+                    if (d > 0) == z:
+                        w = w + 2 * z - 1
+    return w
+
+
+@njit
+def points_in_polys(xs, ys, polys, inon=True, closedPolys=False):
+    """
+    Checks a set of points to determine those which are in a set of polygons
+
+    Parameters:
+        :xs: The x coordinates of the points to test (1D numpy array)
+        :ys: The y coordinates of the points to test (must be the same size of xs)
+        :polys: A tuple of numpy arrays size (N, 2), where the first column
+                contains the x coordinates of a polygon and the second the y
+        :inon: If True consider points on edges and vertices as inside the polygon
+        :closedPolys: If True the polygons are closed in the polygons' coordinate definitions
+
+    Returns:
+        :vector: A vector the size of xs which has a nonzero at an index, i, corresponding to (xs[i], ys[i]) if the point is within the polygons.
+    """
+    n = xs.size
+    inpoly = np.zeros(n, dtype=np.int16)
+    for p in polys:
+        vx = p[:, 0]
+        vy = p[:, 1]
+        # compute bounding box
+        maxvx = np.max(vx)
+        minvx = np.min(vx)
+        maxvy = np.max(vy)
+        minvy = np.min(vy)
+        # close the poly
+        if not closedPolys:
+            (Px, Py) = close_poly(vx, vy)
+        else:
+            Px = vx
+            Py = vy
+        for k in range(n):
+            # see if it is already in a polygon, if so, skip
+            if inpoly[k] == False:
+                x = xs[k]
+                y = ys[k]
+                if x >= minvx and x <= maxvx:
+                    if y >= minvy and y <= maxvy:
+                        if point_in_poly(x, y, Px, Py, inon, True):
+                            inpoly[k] = True
+    return inpoly
+
+
+@njit
+def vec_points_in_polys(x_vec, y_vec, polys, inon=True, closedPolys=False):
+    """
+    Checks a set of points defined by the meshgrid of two input vectors to determine
+    those which are in a set of polygons.
+
+    Parameters:
+        :x_vec: The x coordinates of the points to test (1D numpy array)
+        :y_vec: The y coordinates of the points to test (1D numpy array)
+        :polys: A tuple of numpy arrays size (N, 2), where the first column contains the x coordinates of a polygon and the second the y.
+        :inon: If True consider points on edges and vertices as inside the polygon
+        :closedPolys: If True the polygons are closed in the polygons' coordinate definitions.
+
+    Returns:
+        :array: an array size (x_vec.size, y_vect.size) which has a nonzero at an index  (i, j), corresponding to:
+
+            (X, Y) = meshgrid(x_vec, y_vec);
+            (X[i], Y[j]) if the point is within the polygons.
+            
+    """
+    nx = x_vec.size
+    ny = y_vec.size
+    inpoly = np.zeros((nx, ny), dtype=np.int16)
+    for p in polys:
+        vx = p[:, 0]
+        vy = p[:, 1]
+        # compute bounding box
+        maxvx = np.max(vx)
+        minvx = np.min(vx)
+        maxvy = np.max(vy)
+        minvy = np.min(vy)
+        # close the poly
+        if not closedPolys:
+            (Px, Py) = close_poly(vx, vy)
+        else:
+            Px = vx
+            Py = vy
+        for ky in range(len(y_vec)):
+            y = y_vec[ky]
+            for kx in range(len(x_vec)):
+                x = x_vec[kx]
+                # see if it is already in a polygon, if so, skip
+                if inpoly[ky, kx] == False:
+                    if x >= minvx and x <= maxvx:
+                        if y >= minvy and y <= maxvy:
+                            if point_in_poly(x, y, Px, Py, inon, True):
+                                inpoly[ky, kx] = True
+    return inpoly
+
+
+def plot_poly(plt, poly_x, poly_y):
+    # Debug helper, will plot a polygon into plt's gcf
+    length = len(poly_x) + 1
+    pthcode = [Path.LINETO] * length
+    pthcode[0] = Path.MOVETO
+    pthcode[-1] = Path.CLOSEPOLY
+    q = np.zeros([length, 2])
+    q[:-1, 0] = poly_x
+    q[:-1, 1] = poly_y
+    q[-1, 0] = poly_x[0]
+    q[-1, 1] = poly_y[0]
+    path = Path(q, pthcode)
+    patch = patches.PathPatch(path, facecolor='green', lw=2, alpha=0.3)
+    plt.gca().add_patch(patch)

--- a/earthio/filters/preproc_scale.py
+++ b/earthio/filters/preproc_scale.py
@@ -1,0 +1,181 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+--------------------------------
+
+``earthio.filters.prepoc_scale``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+import copy
+from functools import WRAPPER_ASSIGNMENTS, wraps, partial
+
+from ..elm_store import ElmStore
+import numpy as np
+import sklearn.feature_selection as skfeat
+import sklearn.preprocessing as skpre
+import xarray as xr
+
+from .config.func_signatures import get_args_kwargs_defaults
+from .step_mixin import StepMixin
+
+from six import string_types
+
+class SklearnBase(StepMixin):
+    def __init__(self,  **kwargs):
+        cls = getattr(skfeat, self.__class__.__name__, None)
+        if cls is None:
+            cls = getattr(skpre, self.__class__.__name__)
+        args, defaults, var_kwargs = get_args_kwargs_defaults(cls.__init__)
+        kw = {k: v for k, v in kwargs.items() if k in defaults or k in args}
+        self._estimator = cls(**kw) # init on that class
+
+    def require_flat(self, X):
+        if not (isinstance(X, (ElmStore, xr.Dataset)) and hasattr(X, 'flat')):
+            raise ValueError("Expected an earthio.ElmStore or xarray.Dataset with DataArray 'flat' (2-d array with dims [space, band])")
+
+    def _filter_kw(self, func, X, y=None, sample_weight=None, **kwargs):
+        args, defaults, var_kwargs = get_args_kwargs_defaults(func)
+        kw = dict(y=y, sample_weight=sample_weight, **kwargs)
+        kw = {k: v for k, v in kw.items() if k in defaults or k in args}
+        return ((X.flat.values,), kw, y, sample_weight)
+
+    def get_params(self, **kwargs):
+        params = self._estimator.get_params()
+        return self._estimator.get_params(**kwargs)
+
+    def set_params(self, **params):
+        kwargs = {k: v for k, v in params.items()
+                  if k in self._estimator.get_params()}
+        self._estimator.set_params(**kwargs)
+        self_kwargs = {k: v for k, v in params.items()
+                       if k not in kwargs}
+        for k, v in self_kwargs.items():
+            setattr(self, k, v)
+
+    def transform(self, *args, **kwargs):
+        X = args[0]
+        self.require_flat(X)
+        args, kwargs, y, sample_weight = self._filter_kw(self._estimator.transform, *args, **kwargs)
+        new_X = self._estimator.transform(*args, **kwargs)
+        X = self._to_elm_store(new_X, X)
+        return (X, y, sample_weight)
+
+    def fit_transform(self, *args, **kwargs):
+        X = args[0]
+        if hasattr(self._estimator, 'fit_transform'):
+            self.require_flat(X)
+            args, kwargs, y, sample_weight = self._filter_kw(self._estimator.fit_transform, *args, **kwargs)
+            new_X = self._estimator.fit_transform(*args, **kwargs)
+            X = self._to_elm_store(new_X, X)
+            return (X, y, sample_weight)
+        self._estimator = self.fit(*args, **kwargs)
+        return self.transform(*args, **kwargs)
+
+    def fit(self, *args, **kwargs):
+        X = args[0]
+        self.require_flat(X)
+        args, kwargs, _, _ = self._filter_kw(self._estimator.fit, *args, **kwargs)
+        return self._estimator.fit(*args, **kwargs)
+
+    def _to_elm_store(self, X, old_X):
+        attrs = copy.deepcopy(old_X.attrs)
+        attrs.update(copy.deepcopy(old_X.flat.attrs))
+        band = ['feat_{}'.format(idx) for idx in range(X.shape[1])]
+        flat = xr.DataArray(X,
+                            coords=[('space', old_X.flat.space), ('band', band)],
+                            dims=old_X.flat.dims,
+                            attrs=attrs)
+        return ElmStore({'flat': flat}, attrs=attrs)
+
+
+class Binarizer(SklearnBase):
+    '''sklearn.preprocessing.Binarizer for elm.pipeline.Pipeline'''
+
+class FunctionTransformer(SklearnBase):
+    '''sklearn.preprocessing.FunctionTransformer for elm.pipeline.Pipeline'''
+
+class Imputer(SklearnBase):
+    '''sklearn.preprocessing.Imputer for elm.pipeline.Pipeline'''
+
+class KernelCenterer(SklearnBase):
+    '''sklearn.preprocessing.KernelCenterer for elm.pipeline.Pipeline'''
+
+class LabelBinarizer(SklearnBase):
+    '''sklearn.preprocessing.LabelBinarizer for elm.pipeline.Pipeline'''
+
+class LabelEncoder(SklearnBase):
+    '''sklearn.preprocessing.LabelEncoder for elm.pipeline.Pipeline'''
+
+class MaxAbsScaler(SklearnBase):
+    '''sklearn.preprocessing.MaxAbsScaler for elm.pipeline.Pipeline'''
+
+class MinMaxScaler(SklearnBase):
+    '''sklearn.preprocessing.MinMaxScaler for elm.pipeline.Pipeline'''
+
+class MultiLabelBinarizer(SklearnBase):
+    '''sklearn.preprocessing.MultiLabelBinarizer for elm.pipeline.Pipeline'''
+
+class Normalizer(SklearnBase):
+    '''sklearn.preprocessing.Normalizer for elm.pipeline.Pipeline'''
+
+class OneHotEncoder(SklearnBase):
+    '''sklearn.preprocessing.OneHotEncoder for elm.pipeline.Pipeline'''
+
+class PolynomialFeatures(SklearnBase):
+    '''sklearn.preprocessing.PolynomialFeatures for elm.pipeline.Pipeline'''
+
+class RobustScaler(SklearnBase):
+    '''sklearn.preprocessing.RobustScaler for elm.pipeline.Pipeline'''
+
+class StandardScaler(SklearnBase):
+    '''sklearn.preprocessing.StandardScaler for elm.pipeline.Pipeline'''
+
+class RFE(SklearnBase):
+    '''sklearn.feature_selection.RFE for elm.pipeline.Pipeline'''
+
+class RFECV(SklearnBase):
+    '''sklearn.feature_selection.RFECV for elm.pipeline.Pipeline'''
+
+class SelectFdr(SklearnBase):
+    '''sklearn.feature_selection.SelectFdr for elm.pipeline.Pipeline'''
+
+class SelectFpr(SklearnBase):
+    '''sklearn.feature_selection.SelectFpr for elm.pipeline.Pipeline'''
+
+class SelectFromModel(SklearnBase):
+    '''sklearn.feature_selection.SelectFromModel for elm.pipeline.Pipeline'''
+
+class SelectFwe(SklearnBase):
+    '''sklearn.feature_selection.SelectFwe for elm.pipeline.Pipeline'''
+
+class SelectKBest(SklearnBase):
+    '''sklearn.feature_selection.SelectKBest for elm.pipeline.Pipeline'''
+
+class SelectPercentile(SklearnBase):
+    '''sklearn.feature_selection.SelectPercentile for elm.pipeline.Pipeline'''
+
+class VarianceThreshold(SklearnBase):
+    '''sklearn.feature_selection.VarianceThreshold for elm.pipeline.Pipeline'''
+
+
+gs = tuple(globals().items())
+clses = [(k, v) for k, v in gs if isinstance(v, type) and issubclass(v, SklearnBase)]
+SKLEARN_PREPROCESSING = {}
+for k, cls in clses:
+    SKLEARN_PREPROCESSING[k] = cls
+
+def require_positive(X, small_num=0.0001):
+    '''Helper function to ensure positivity before functions like "log"
+
+    Params:
+        :X:  numpy array
+        :small_num: small float number which should replace values <= 0'''
+
+
+    if X.dtype.kind != 'f':
+        X = X.astype(np.float32)
+    X[np.where(X <= 0)] = small_num
+    return X
+
+__all__ = [k for k,v in gs if k[0].isupper() and k[0] != '_']

--- a/earthio/filters/preproc_scale.py
+++ b/earthio/filters/preproc_scale.py
@@ -10,14 +10,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 from functools import WRAPPER_ASSIGNMENTS, wraps, partial
 
-from ..elm_store import ElmStore
+from earthio.elm_store import ElmStore
 import numpy as np
 import sklearn.feature_selection as skfeat
 import sklearn.preprocessing as skpre
 import xarray as xr
 
-from .config.func_signatures import get_args_kwargs_defaults
-from .step_mixin import StepMixin
+from earthio.filters.config.func_signatures import get_args_kwargs_defaults
+from earthio.filters.step_mixin import StepMixin
 
 from six import string_types
 

--- a/earthio/filters/sample_pipeline.py
+++ b/earthio/filters/sample_pipeline.py
@@ -1,0 +1,199 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+-----------------------------------
+
+``earthio.sample_util.sample_pipeline``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Utilities for taking the "pipelines" section of an elm
+config and creating an elm.pipeline.Pipeline from them
+'''
+
+from collections import Sequence
+import copy
+from functools import partial
+import logging
+from pprint import pformat
+
+from ..elm_store import ElmStore
+from ..reshape import flatten as _flatten
+import numpy as np
+import xarray as xr
+from sklearn.utils import check_array as _check_array
+import sklearn.preprocessing as skpre
+import sklearn.feature_selection as skfeat
+
+from .config.func_signatures import get_args_kwargs_defaults
+from .change_coords import CHANGE_COORDS_ACTIONS
+from .preproc_scale import SKLEARN_PREPROCESSING
+try:
+    from .. import load_meta, load_array
+except ImportError:
+    load_array = load_meta = None
+
+from six import string_types
+
+logger = logging.getLogger(__name__)
+
+_SAMPLE_PIPELINE_SPECS = {}
+
+
+def _split_pipeline_output(output, X, y,
+                           sample_weight, context):
+    '''Util to ensure a Pipeline func always returns (X, y, sample_weight) tuple'''
+    if not isinstance(output, (tuple, list)):
+        ret = output, y, sample_weight
+    elif output is None:
+        ret = X, y, sample_weight
+    elif len(output) == 1:
+        ret = output[0], y, sample_weight
+    elif len(output) == 2:
+        xx = output[0] if output[0] is not None else X
+        yy = output[1] if output[1] is not None else y
+        ret = (xx, yy, sample_weight,)
+    elif len(output) == 3:
+        xx = output[0] if output[0] is not None else X
+        yy = output[1] if output[1] is not None else y
+        sw = output[2] if output[2] is not None else sample_weight
+        ret = (xx, yy, sw)
+    else:
+        raise ValueError('{} pipeline func returned '
+                         'more than 3 outputs in a '
+                         'tuple/list'.format(context))
+    assert isinstance(ret, tuple) and not isinstance(ret[0], tuple)
+    return ret
+
+
+def create_sample_from_data_source(config=None, **data_source):
+    '''Given sampling specs in a pipeline train or predict step,
+    return pipe, a list of (func, args, kwargs) actions
+
+    Params:
+        :train_or_predict_dict: a "train" or "predict" dict from config
+        :config:                full config
+        :step:                  a dictionary that is the current step in the pipeline, like a "train" or "predict" step
+
+    '''
+    sampler_func = data_source['sampler'] # TODO: this needs to be
+                                                        # added to ConfigParser
+                                                        # validation (sampler requirement)
+    sampler_args = data_source.get('sampler_args') or ()
+    if not isinstance(sampler_args, (tuple, list)):
+        sampler_args = (sampler_args,)
+    reader_name = data_source.get('reader') or None
+    if isinstance(reader_name, string_types) and reader_name:
+        if config and reader_name in config.readers:
+            reader = config.readers[reader_name]
+        _load_meta = partial(load_meta, reader=reader_name)
+        _load_array = partial(load_array, reader=reader_name)
+    elif isinstance(reader_name, dict):
+        reader = reader_name
+        _load_meta = reader['load_meta']
+        _load_array = reader['load_array']
+    else:
+        _load_array = load_array
+        _load_meta = load_meta
+    data_source['load_meta'] = _load_meta
+    data_source['load_array'] = _load_array
+    return sampler_func(*sampler_args, **data_source)
+
+
+def check_array(arr, msg, **kwargs):
+    '''Util func for checking sample remains finite and not-NaN'''
+    if arr is None:
+        raise ValueError('Array cannot be None ({}): '.format(msg))
+    try:
+        _check_array(arr, **kwargs)
+    except Exception as e:
+        shp = getattr(arr, 'shape', '(has no shape attribute)')
+        logger.info('Failed on check_array on array with shape '
+                    '{}'.format(shp))
+
+        raise ValueError('check_array ({}) failed with {}'.format(msg, repr(e)))
+
+
+def _has_arg(a):
+    return not (a is None or (isinstance(a, list) and not a) or (hasattr(a, 'size') and a.size == 0))
+
+
+def final_on_sample_step(fitter,
+                         model, X,
+                         fit_kwargs,
+                         y=None,
+                         sample_weight=None,
+                         require_flat=True,
+                         prepare_for='train'):
+    '''This is the final transformation before the last estimator
+    in a Pipeline is called.  It takes the numpy array for X
+    needed by the estimator from X as an ElmStore
+
+    Parameters:
+        :fitter: fit function object
+        :model:  the final estimator in a Pipeline
+        :X:      ElmStore with DataArray "flat"
+        :fit_kwargs: kwargs to fitter
+        :y:      numpy array y if needed
+        :sample_weight: numpy array if needed
+        :require_flat: raise an error if the ElmStore has no "flat" band
+        :prepare_for:  determines whether y is included in fit_args
+
+    Returns
+        :args, kwargs: that fitter should use
+
+    '''
+    fit_kwargs = copy.deepcopy(fit_kwargs or {})
+    if y is None:
+        y = fit_kwargs.pop('y', None)
+    else:
+        fit_kwargs.pop('y', None)
+    if sample_weight is None:
+        sample_weight = fit_kwargs.pop('sample_weight', None)
+    else:
+        fit_kwargs.pop('sample_weight', None)
+    if isinstance(X, np.ndarray):
+        X_values = X             # numpy array 2-d
+    elif isinstance(X, (ElmStore, xr.Dataset)):
+        if hasattr(X, 'flat'):
+            X_values = X.flat.values
+        else:
+            logger.info("After running Pipeline, X is not an ElmStore with a DataArray called 'flat' and X is not a numpy array.  Found {}".format(type(X)))
+            logger.info("Trying earthio.reshape:flatten on X. If this fails, try a elm.pipeline.steps:ModifySample step to create ElmStore with 'flat' DataArray")
+            X = _flatten(X)
+            X_values = X.flat.values
+    else:
+        X_values = X # may not be okay for sklearn models,e.g KMEans but can be passed thru Pipeline
+    if X_values.ndim == 1:
+        X_values = X_values.reshape(-1, 1)
+    args, kwargs, var_keyword = get_args_kwargs_defaults(fitter)
+
+    has_y = _has_arg(y)
+    has_sw = _has_arg(sample_weight)
+    if has_sw:
+        fit_kwargs['sample_weight'] = sample_weight
+    if 'check_input' in kwargs:
+        fit_kwargs['check_input'] = True
+    if has_y:
+        if prepare_for == 'train':
+            fit_args = (X_values, y)
+        else:
+            fit_args = (X,)
+        logger.debug('X (shape {}) and y (shape {})'.format(X_values.shape, y.shape))
+    else:
+        if prepare_for == 'train':
+            fit_args = (X_values,)
+        else:
+            fit_args = (X,)
+        logger.debug('X (shape {})'.format(X_values.shape))
+    check_array(X_values, "final_on_sample_step - X")
+    if has_y:
+        if y.size != X_values.shape[0]:
+            raise ValueError("Bad size for y ({}) - does not match X.shape[0] ({})".format(y.size, X_values.shape[0]))
+    if has_sw:
+        if not sample_weight.size == X_values.shape[0]:
+            raise ValueError("Bad size for sample_weight ({}) - does not match X.shape[0] ({})".format(sample_weight.size, X_values.shape[0]))
+    if 'batch_size' in model.get_params():
+        logger.debug('set batch_size {}'.format(X_values.shape[0]))
+        model.set_params(batch_size=X_values.shape[0])
+    return fit_args, fit_kwargs
+

--- a/earthio/filters/sample_pipeline.py
+++ b/earthio/filters/sample_pipeline.py
@@ -16,17 +16,17 @@ from functools import partial
 import logging
 from pprint import pformat
 
-from ..elm_store import ElmStore
-from ..reshape import flatten as _flatten
+from earthio.elm_store import ElmStore
+from earthio.reshape import flatten as _flatten
 import numpy as np
 import xarray as xr
 from sklearn.utils import check_array as _check_array
 import sklearn.preprocessing as skpre
 import sklearn.feature_selection as skfeat
 
-from .config.func_signatures import get_args_kwargs_defaults
-from .change_coords import CHANGE_COORDS_ACTIONS
-from .preproc_scale import SKLEARN_PREPROCESSING
+from earthio.filters.config.func_signatures import get_args_kwargs_defaults
+from earthio.filters.change_coords import CHANGE_COORDS_ACTIONS
+from earthio.filters.preproc_scale import SKLEARN_PREPROCESSING
 try:
     from .. import load_meta, load_array
 except ImportError:

--- a/earthio/filters/samplers.py
+++ b/earthio/filters/samplers.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+-----------------------------
+
+``earthio.filters.samplers``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+from collections import namedtuple
+
+import attr
+import numpy as np
+import pandas as pd
+
+sample_idx = 0
+def _next_name(token):
+    global sample_idx
+    s = '{}_{}'.format(token, sample_idx)
+    sample_idx += 1
+    return s
+
+
+def _make_sample(pipe, args, sampler, data_source):
+    out = pipe.create_sample(sampler=sampler, sampler_args=args,
+                             **{k: v for k, v in data_source.items()
+                                if k not in ('sampler', 'sampler_args')})
+    return out
+
+
+def make_samples(pipe, args_list, sampler, data_source):
+    dsk = {}
+    if not args_list:
+        if 'sampler_args' in data_source:
+            args_list = [data_source['sampler_args']]
+        else:
+            raise ValueError('Expected "args_list" or "sampler_args" in data_source')
+    for arg in args_list:
+        sample_name = _next_name('make_samples_dask')
+        dsk[sample_name] = (_make_sample, pipe, arg, sampler, data_source)
+    return dsk
+
+
+def make_samples_dask(X, y, sample_weight, pipe, args_list, sampler, data_source):
+    '''Dask graph of sampler calls, used in ensemble and EA methods
+
+    Parameters:
+        :X:  ElmStore or None
+        :y:  numpy array or None
+        :sample_weight: numpy array or None
+        :args_list: arguments to pass to sampler
+        :sampler: function called on each element of args_list sampler(\*each_element) if X not given
+        :data_source: keyword args to sampler
+
+    Returns:
+        :dsk:  Dask dict
+
+    '''
+    if X is None:
+        dsk = make_samples(pipe, args_list, sampler, data_source)
+    else:
+        dsk = {_next_name('make_samples_dask'): (lambda: (X, y, sample_weight),)}
+    return dsk

--- a/earthio/filters/step_mixin.py
+++ b/earthio/filters/step_mixin.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+---------------------------------
+
+``earthio.filters.step_mixin``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+
+class StepMixin(object):
+    '''Base class for any step in an elm.pipeline.Pipeline'''
+    _sp_step = None
+    _func = None
+    _required_kwargs = None
+    _context = 'sample pipeline step'
+
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self.func = kwargs.pop('func', self._func)
+        self._kwargs = kwargs
+
+        if self.func:
+            self.func = self.func(*args, **kwargs)
+        self._validate_init_base()
+        if callable(getattr(self, '_validate_init', None)):
+            self._validate_init(*self._args, **self._kwargs)
+
+    def get_params(self, **kwargs):
+        func = getattr(self.func, 'get_params', None)
+        if func:
+            return func(**kwargs)
+        return self._kwargs
+
+    def _validate_init_base(self):
+        if self._sp_step is None:
+            raise ValueError('Expected inheriting class to define _sp_step')
+
+    _filter_kw = None
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        ft = getattr(self.func, 'fit_transform', None)
+        dot_transform = False
+        if not callable(ft):
+            ft = getattr(self.func, 'fit', None)
+            if ft is not None:
+                dot_transform = True
+            else:
+                ft = self.func
+        kw = kwargs.copy()
+        if sample_weight is not None:
+            kw['sample_weight'] = sample_weight
+        if callable(self._filter_kw):
+            args, kwargs = self._filter_kw(ft, X, y=y, **kw)
+        else:
+            args, kwargs = (X, y), kw
+        output = ft(*args, **kwargs)
+        if dot_transform:
+            output = output.transform(X.flat.values)
+        return _split_pipeline_output(output, X, y, sample_weight,
+                                      getattr(self, '_context', ft))
+
+    def __repr__(self):
+        name = self.__class__.__name__
+        params = ('{}: {}'.format(k, repr(v))
+                  for k, v in sorted(self.get_params().items()))
+        return '<earthio.steps.{}>:\n\t{}'.format(name, '\n\t'.join(params))
+
+    __str__ = __repr__

--- a/earthio/filters/tests/test_bands_operation.py
+++ b/earthio/filters/tests/test_bands_operation.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+
+from elm.config.tests.fixtures import *
+from ..make_blobs import random_elm_store
+from ..bands_operation import *
+
+def setup():
+    X = random_elm_store()
+    band1, band2 = (np.random.choice(X.band_order) for _ in range(2))
+    return X, band1, band2
+
+
+def test_diff():
+    X, band1, band2 = setup()
+    spec = dict(abc=(band1, band2))
+    Xnew, _, _ = BandsDiff(spec=spec).fit_transform(X)
+    assert np.all(Xnew.abc.values == getattr(X, band1).values - getattr(X, band2).values)
+
+def test_normed_diff():
+    X, band1, band2 = setup()
+    spec = dict(abc=(band1, band2))
+    Xnew, _, _ = NormedBandsDiff(spec=spec).fit_transform(X)
+    b1 = getattr(X, band1).values
+    b2 = getattr(X, band2).values
+    nd = (b1 - b2) / (b1 + b2)
+    assert np.all(Xnew.abc.values == nd)
+
+def test_sum():
+    X, band1, band2 = setup()
+    spec = dict(abc=(band1, band2))
+    Xnew, _, _ = BandsSum(spec=spec).fit_transform(X)
+    assert np.all(Xnew.abc.values == getattr(X, band1).values + getattr(X, band2).values)
+
+def test_ratio():
+    X, band1, band2 = setup()
+    spec = dict(abc=(band1, band2))
+    Xnew, _, _ = BandsRatio(spec=spec).fit_transform(X)
+    assert np.all(Xnew.abc.values == getattr(X, band1).values / getattr(X, band2).values)

--- a/earthio/filters/tests/test_bands_operation.py
+++ b/earthio/filters/tests/test_bands_operation.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 
-from elm.config.tests.fixtures import *
+from earthio.filters.config.tests.fixtures import *
 from earthio.filters.make_blobs import random_elm_store
 from earthio.filters.bands_operation import *
 

--- a/earthio/filters/tests/test_bands_operation.py
+++ b/earthio/filters/tests/test_bands_operation.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 
 from elm.config.tests.fixtures import *
-from ..make_blobs import random_elm_store
-from ..bands_operation import *
+from earthio.filters.make_blobs import random_elm_store
+from earthio.filters.bands_operation import *
 
 def setup():
     X = random_elm_store()

--- a/earthio/filters/tests/test_change_coords.py
+++ b/earthio/filters/tests/test_change_coords.py
@@ -6,8 +6,7 @@ import pytest
 
 from sklearn.decomposition import PCA
 
-from elm.config import ConfigParser
-from elm.config.tests.fixtures import *
+from earthio.filters.config.tests.fixtures import *
 from earthio.filters.make_blobs import random_elm_store
 from earthio.reshape import *
 from earthio.elm_store import ElmStore
@@ -40,10 +39,12 @@ def make_config(pipeline, data_source):
             }
 
 
+# TODO: Tests that use this function are skipped, due to elm imports
 def tst_one_pipeline(pipeline,
                      add_na_per_band=0,
                      na_fields_as_str=True,
                      delim='_'):
+    from elm.config import ConfigParser
     from elm.sample_util.sample_pipeline import make_pipeline_steps
     sample = random_elm_store()
     if add_na_per_band:

--- a/earthio/filters/tests/test_change_coords.py
+++ b/earthio/filters/tests/test_change_coords.py
@@ -2,17 +2,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 import xarray as xr
+import pytest
 
 from sklearn.decomposition import PCA
 
 from elm.config import ConfigParser
 from elm.config.tests.fixtures import *
-from elm.pipeline.tests.util import (test_one_config as tst_one_config,
-                                     tmp_dirs_context)
-from ..make_blobs import random_elm_store
+from earthio.filters.make_blobs import random_elm_store
 from earthio.reshape import *
-from ..elm_store import ElmStore
-from elm.pipeline import Pipeline
+from earthio.elm_store import ElmStore
 
 X = random_elm_store()
 
@@ -78,6 +76,7 @@ def tst_one_pipeline(pipeline,
     return sample, new_es[0]
 
 
+@pytest.mark.skip('Depends on elm.sample_util.sample_pipeline.make_pipeline_steps')
 def test_flat_and_inverse():
 
     flat = [{'flatten': 'C'}, {'inverse_flatten': True}, {'transpose': ['y', 'x']}]
@@ -85,6 +84,7 @@ def test_flat_and_inverse():
     assert np.all(new_es.band_1.values == es.band_1.values)
 
 
+@pytest.mark.skip('Depends on elm.sample_util.sample_pipeline.make_pipeline_steps')
 def test_agg():
     for dim, axis in zip(('x', 'y'), (1, 0)):
         for r in range(2):
@@ -101,6 +101,7 @@ def test_agg():
             assert np.all(diff < 1e-5)
 
 
+@pytest.mark.skip('Depends on elm.sample_util.sample_pipeline.make_pipeline_steps')
 def test_transpose():
     transpose_examples = {
         'xy': [{'transpose': ['x', 'y']}],
@@ -137,6 +138,7 @@ def modify_sample_example(es, *args, **kwargs):
     return ElmStore(new_es, attrs=es.attrs)
 
 
+@pytest.mark.skip('Depends on elm.sample_util.sample_pipeline.make_pipeline_steps')
 def test_modify_sample():
     modify = [{'modify_sample': 'elm.sample_util.tests.test_change_coords:modify_sample_example'}]
     es, new_es = tst_one_pipeline(modify)
@@ -150,6 +152,7 @@ def test_modify_sample():
         band_arr = getattr(inv, band)
         assert band_arr.values.shape == getattr(new_es, band).values.shape
 
+@pytest.mark.skip('Depends on elm.sample_util.sample_pipeline.make_pipeline_steps')
 def test_agg_inverse_flatten():
     for idx, dims in enumerate((['x', 'y'], ['y', 'x'])):
         for agg_dim in ('x', 'y'):
@@ -172,6 +175,7 @@ def test_agg_inverse_flatten():
                 assert x1 is not None and x2 is not None
 
 
+@pytest.mark.skip('Depends on elm.sample_util.sample_pipeline.make_pipeline_steps')
 def test_set_na_from_meta():
     set_na = [{'modify_sample': 'earthio:set_na_from_meta'}]
     for delim in ('_', '-', ' ', '   '):

--- a/earthio/filters/tests/test_change_coords.py
+++ b/earthio/filters/tests/test_change_coords.py
@@ -1,0 +1,185 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+import xarray as xr
+
+from sklearn.decomposition import PCA
+
+from elm.config import ConfigParser
+from elm.config.tests.fixtures import *
+from elm.pipeline.tests.util import (test_one_config as tst_one_config,
+                                     tmp_dirs_context)
+from ..make_blobs import random_elm_store
+from earthio.reshape import *
+from ..elm_store import ElmStore
+from elm.pipeline import Pipeline
+
+X = random_elm_store()
+
+data_source = {'X': X}
+
+train = {'model_init_class': 'sklearn.cluster:MiniBatchKMeans',
+         'ensemble': 'ens1'}
+
+
+def make_run(pipeline, data_source):
+    run = [{'data_source': 'synthetic',
+            'pipeline': pipeline,
+            'train': 'ex1'}]
+    return run
+
+
+def make_config(pipeline, data_source):
+    return   {'train': {'ex1': train},
+              'data_sources': {'synthetic': data_source},
+              'run': make_run(pipeline, data_source),
+              'ensembles': {
+                'ens1': {
+                    'saved_ensemble_size': 1,
+                    'init_ensemble_size': 1
+                }
+              }
+            }
+
+
+def tst_one_pipeline(pipeline,
+                     add_na_per_band=0,
+                     na_fields_as_str=True,
+                     delim='_'):
+    from elm.sample_util.sample_pipeline import make_pipeline_steps
+    sample = random_elm_store()
+    if add_na_per_band:
+        for idx, band in enumerate(sample.data_vars):
+            band_arr = getattr(sample, band)
+            val = band_arr.values
+            inds = np.arange(val.size)
+            np.random.shuffle(inds)
+            x = inds // val.shape[0]
+            y = inds % val.shape[0]
+            slc = slice(None, add_na_per_band // 2)
+            val[y[slc],x[slc]] = 99 * idx
+            band_arr.attrs['missing{}value'.format(delim)] = 99 * idx
+            slc = slice(add_na_per_band // 2, add_na_per_band)
+            val[y[slc], x[slc]] = 199 * idx
+            band_arr.attrs['invalid{}range'.format(delim)] = [198 * idx, 200 * idx]
+            band_arr.attrs['valid{}range'.format(delim)] = [-1e12, 1e12]
+            if na_fields_as_str:
+                for field in ('missing{}value', 'invalid{}range', 'valid{}range'):
+                    field = field.format(delim)
+                    v = band_arr.attrs[field]
+                    if isinstance(v, list):
+                        band_arr.attrs[field] = ', '.join(map(str,v))
+                    else:
+                        band_arr.attrs[field] = str(v)
+            assert val[np.isnan(val)].size == 0
+    config = ConfigParser(config=make_config(pipeline, data_source))
+    pipe = Pipeline(make_pipeline_steps(config, pipeline))
+    new_es = pipe.fit_transform(sample)
+    return sample, new_es[0]
+
+
+def test_flat_and_inverse():
+
+    flat = [{'flatten': 'C'}, {'inverse_flatten': True}, {'transpose': ['y', 'x']}]
+    es, new_es = tst_one_pipeline(flat)
+    assert np.all(new_es.band_1.values == es.band_1.values)
+
+
+def test_agg():
+    for dim, axis in zip(('x', 'y'), (1, 0)):
+        for r in range(2):
+            if r == 0:
+                agg = [{'agg': {'dim': dim, 'func': 'mean'}}]
+            else:
+                agg = [{'agg': {'axis': axis, 'func': 'mean'}}]
+            es, new_es = tst_one_pipeline(agg)
+            assert dim in es.band_1.dims
+            assert dim not in new_es.band_1.dims
+            means = np.mean(es.band_1.values, axis=axis)
+            new_means = new_es.band_1.values
+            diff = np.abs(means - new_means)
+            assert np.all(diff < 1e-5)
+
+
+def test_transpose():
+    transpose_examples = {
+        'xy': [{'transpose': ['x', 'y']}],
+        'inv': [{'flatten': 'C'},
+         {'transpose': ['band', 'space']},
+         {'transpose': ['space', 'band']},
+         {'inverse_flatten': True},
+         {'transpose': ['y', 'x']},
+        ]
+    }
+    transpose_examples['fl'] = transpose_examples['xy'] + [{'flatten': 'C'}, {'inverse_flatten': True}, ]
+    for name, pipeline in sorted(transpose_examples.items()):
+        es, new_es = tst_one_pipeline(pipeline)
+        if name == 'fl':
+            assert es.band_1.values.T.shape == new_es.band_1.values.shape
+            assert np.all(es.band_1.values.T == new_es.band_1.values)
+        if name == 'xy':
+            assert es.band_1.values.shape == (new_es.band_1.values.shape[1], new_es.band_1.values.shape[0])
+            assert np.all(es.band_1.values.T == new_es.band_1.values)
+        if 'inv' in name:
+            assert es.band_1.values.shape == new_es.band_1.values.shape
+            diff = es.band_1.values - new_es.band_1.values
+            assert np.all(np.abs(diff) < 1e-5)
+
+def modify_sample_example(es, *args, **kwargs):
+
+    new_es = {}
+    for band in es.data_vars:
+        band_arr = getattr(es, band)
+        v = band_arr.values / band_arr.values.mean(axis=0)
+        new_es[band] = xr.DataArray(v, coords=band_arr.coords, dims=band_arr.dims)
+        v2 = (band_arr.T.values / band_arr.values.mean(axis=1)).T
+        new_es[band + '_new'] = xr.DataArray(v2, coords=band_arr.coords, dims=band_arr.dims)
+    return ElmStore(new_es, attrs=es.attrs)
+
+
+def test_modify_sample():
+    modify = [{'modify_sample': 'elm.sample_util.tests.test_change_coords:modify_sample_example'}]
+    es, new_es = tst_one_pipeline(modify)
+    assert np.all([np.all(getattr(es,b).values.shape == getattr(new_es, b).values.shape) for b in es.data_vars])
+    new_names = set(es.band_order) - set(new_es.band_order)
+    assert all('new' in n for n in new_names)
+    flat = flatten(new_es)
+    assert not len(set(tuple(flat.flat.band.values)) ^ set(new_es.band_order))
+    inv = inverse_flatten(flat)
+    for band in inv.data_vars:
+        band_arr = getattr(inv, band)
+        assert band_arr.values.shape == getattr(new_es, band).values.shape
+
+def test_agg_inverse_flatten():
+    for idx, dims in enumerate((['x', 'y'], ['y', 'x'])):
+        for agg_dim in ('x', 'y'):
+            agg = {'agg': {'dim': agg_dim, 'func': 'median'}}
+            pipeline = [{'transpose': dims},
+                               {'flatten': 'C'},
+                               {'inverse_flatten': True},
+                               {'transpose': dims}]
+            es, new_es = tst_one_pipeline(pipeline)
+            if idx == 0:
+                assert new_es.band_1.shape == es.band_1.values.T.shape
+            es, new_es = tst_one_pipeline(pipeline + [agg])
+            x1, x2 = (getattr(s.band_1, 'x', None) for s in (es, new_es))
+            y1, y2 = (getattr(s.band_1, 'y', None) for s in (es, new_es))
+            if agg_dim == 'x':
+                assert x1 is not None and x2 is None
+                assert y1 is not None and y2 is not None
+            else:
+                assert y1 is not None and y2 is None
+                assert x1 is not None and x2 is not None
+
+
+def test_set_na_from_meta():
+    set_na = [{'modify_sample': 'earthio:set_na_from_meta'}]
+    for delim in ('_', '-', ' ', '   '):
+        for as_str in (True, False):
+            es, new_es = tst_one_pipeline(set_na, add_na_per_band=13,
+                                          na_fields_as_str=as_str,
+                                          delim=delim)
+            assert np.all([np.all(getattr(es,b).values.shape == getattr(new_es, b).values.shape) for b in es.data_vars])
+            for band in es.data_vars:
+                has_nan = getattr(new_es, band).values
+                assert has_nan.size - 13 == has_nan[~np.isnan(has_nan)].size

--- a/earthio/filters/tests/test_feature_selection.py
+++ b/earthio/filters/tests/test_feature_selection.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from earthio.elm_store import ElmStore
 import numpy as np
 
-from elm.config.tests.fixtures import *
-#from elm.pipeline import steps
+from earthio.filters.config.tests.fixtures import *
 from earthio.filters.make_blobs import random_elm_store
 from earthio.reshape import *
 

--- a/earthio/filters/tests/test_feature_selection.py
+++ b/earthio/filters/tests/test_feature_selection.py
@@ -1,21 +1,23 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from ..elm_store import ElmStore
+from earthio.elm_store import ElmStore
 import numpy as np
 
 from elm.config.tests.fixtures import *
-from elm.pipeline import steps
-from ..make_blobs import random_elm_store
+#from elm.pipeline import steps
+from earthio.filters.make_blobs import random_elm_store
 from earthio.reshape import *
+
+from sklearn.feature_selection import f_classif
 
 X = random_elm_store()
 flat_X = flatten(X)
 y = flat_X.flat.values.mean(axis=1)
 var = np.var(flat_X.flat.values, axis=0)
 med = np.median(var)
+@pytest.mark.skip('Depends on elm.pipeline.steps')
 def test_variance_threshold():
-
-    t = steps.VarianceThreshold(threshold=med, score_func='f_classif')
+    t = steps.VarianceThreshold(threshold=med, score_func=f_classif)
     X_new, y2, sample_weight = t.fit_transform(flat_X, y)
     assert np.all(y == y2)
     assert sample_weight is None
@@ -24,8 +26,9 @@ def test_variance_threshold():
     assert X_new.flat.values.shape[1] < flat_X.flat.values.shape[1]
 
 
+@pytest.mark.skip('Depends on elm.pipeline.steps')
 def test_select_percentile():
-    t = steps.SelectPercentile(percentile=50, score_func='f_classif')
+    t = steps.SelectPercentile(percentile=50, score_func=f_classif)
     X_new, y2, sample_weight = t.fit_transform(flat_X, y)
     assert np.all(y == y2)
     assert sample_weight is None

--- a/earthio/filters/tests/test_feature_selection.py
+++ b/earthio/filters/tests/test_feature_selection.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ..elm_store import ElmStore
+import numpy as np
+
+from elm.config.tests.fixtures import *
+from elm.pipeline import steps
+from ..make_blobs import random_elm_store
+from earthio.reshape import *
+
+X = random_elm_store()
+flat_X = flatten(X)
+y = flat_X.flat.values.mean(axis=1)
+var = np.var(flat_X.flat.values, axis=0)
+med = np.median(var)
+def test_variance_threshold():
+
+    t = steps.VarianceThreshold(threshold=med, score_func='f_classif')
+    X_new, y2, sample_weight = t.fit_transform(flat_X, y)
+    assert np.all(y == y2)
+    assert sample_weight is None
+    assert isinstance(X_new, ElmStore)
+    assert hasattr(X_new, 'flat')
+    assert X_new.flat.values.shape[1] < flat_X.flat.values.shape[1]
+
+
+def test_select_percentile():
+    t = steps.SelectPercentile(percentile=50, score_func='f_classif')
+    X_new, y2, sample_weight = t.fit_transform(flat_X, y)
+    assert np.all(y == y2)
+    assert sample_weight is None
+    assert isinstance(X_new, ElmStore)
+    assert hasattr(X_new, 'flat')
+    assert X_new.flat.values.shape[1] < flat_X.flat.values.shape[1]
+
+

--- a/earthio/filters/tests/test_polygon_tools.py
+++ b/earthio/filters/tests/test_polygon_tools.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # set to debug, will plot out polygons etc
 _DEBUG = False
 
-from elm.config.tests.fixtures import *
+from earthio.filters.config.tests.fixtures import *
 from earthio.filters.polygon_tools import (points_in_polys,
                                            vec_points_in_polys,
                                            plot_poly,

--- a/earthio/filters/tests/test_polygon_tools.py
+++ b/earthio/filters/tests/test_polygon_tools.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 _DEBUG = False
 
 from elm.config.tests.fixtures import *
-from ..polygon_tools import (points_in_polys,
-                             vec_points_in_polys,
-                             plot_poly,
-                             close_poly)
+from earthio.filters.polygon_tools import (points_in_polys,
+                                           vec_points_in_polys,
+                                           plot_poly,
+                                           close_poly)
 import numpy as np
 from itertools import product
 

--- a/earthio/filters/tests/test_polygon_tools.py
+++ b/earthio/filters/tests/test_polygon_tools.py
@@ -1,0 +1,148 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+# set to debug, will plot out polygons etc
+_DEBUG = False
+
+from elm.config.tests.fixtures import *
+from ..polygon_tools import (points_in_polys,
+                             vec_points_in_polys,
+                             plot_poly,
+                             close_poly)
+import numpy as np
+from itertools import product
+
+if _DEBUG:
+    import matplotlib.pyplot as plt
+
+
+def test_points_in_poly_functions():
+    # Tests the point in polygon functionality.
+
+    # These polygons are "specially" designed. There are three, a quadrilateral,
+    # a backwards C shape and a square.
+    # The quad poly is defined clockwise and hangs off the grid in the Y direction
+    # and has:
+    #  * Two of the edges intersect a point somewhere on their length.
+    # The backwards C poly is defined anti-clockwise and has:
+    #  * A flat bottom edge for edge detection testing.
+    #  * The third and sixth vertex is exactly on a grid point for testing
+    #    point detection.
+    #  * Hangs off the grid in the X direction
+    # The combination of these polygons creates an overlapping shape which has a
+    # hole in the middle (it's a lumpy doughnut). In the hole is a single
+    # point (at [6, 3]) which is not to be selected.
+    # The square poly is defined anti-clockwise and its edges align to the underlying
+    # grid and surround a single point. This polygon does not overlap the others and
+    # is present to check edge detection works on all edges and vertices.
+
+    quad_poly_x = np.array([0.5, 5.7, 7.5, 2.5])
+    quad_poly_y = np.array([0.5, 6.5, 5.5, -1.5])
+    quad_poly = np.array([quad_poly_x, quad_poly_y]).T
+
+    C_poly_x = np.array([0.5, 7.7, 7., 1.5, 1., 6, 6.5, 1.5])
+    C_poly_y = np.array([1., 1., 6, 6.5, 5.5, 4., 3., 2.])
+    C_poly = np.array([C_poly_x, C_poly_y]).T
+
+    sq_poly_x = np.array([5., 7., 7., 5.])
+    sq_poly_y = np.array([7., 7., 9., 9.])
+    sq_poly = np.array([sq_poly_x, sq_poly_y]).T
+
+    all_polys = (quad_poly, C_poly, sq_poly)
+
+    # unique vectors describing the grid
+    scal = 10.
+    x = np.arange(0, scal)
+    y = np.arange(0, scal)
+    # and a grid
+    (X, Y) = np.meshgrid(x, y)
+    Xr = X.ravel()
+    Yr = Y.ravel()
+
+    def grid_func(polys, inon, closedPolys):
+        return points_in_polys(Xr, Yr, polys, inon, closedPolys)
+
+    def vect_func(polys, inon, closedPolys):
+        return vec_points_in_polys(x, y, polys, inon, closedPolys)
+
+    # functions to test, with their grid input wrapped
+    funcs = [grid_func, vect_func]
+
+    # There are 100 points on the grid in total.
+    sz = Xr.size
+
+    # check the functions, and try with open and closed polygons
+    for f, closed in product(funcs, [False, True]):
+        if closed is True:
+            # the polys were defined open so close them here.
+            closed_p = []
+            for p in all_polys:
+                vx = p[:, 0]
+                vy = p[:, 1]
+                (Px, Py) = close_poly(vx, vy)
+                closed_p.append(np.array([Px, Py]).T)
+            polys = tuple(closed_p)
+        else:
+            # use the defined polys
+            polys = all_polys
+
+        # With inon = True:
+        inon = True
+        if _DEBUG:
+            inpoly = f(polys, inon, closed)
+            plt.figure()
+            plt.scatter(Xr[inpoly == 1], Yr[inpoly == 1], c='r', marker='x')
+            plt.hold
+            plt.scatter(Xr[inpoly == 0], Yr[inpoly == 0], c='y')
+            for p in polys:
+                plot_poly(plt, p[:, 0], p[:, 1])
+            plt.show()
+
+        # From a manual count...
+        # The quadrilateral has 21 points in the polygon
+        inpoly = f((polys[0],), inon, closed)
+        assert(np.count_nonzero(inpoly) == 21)
+        assert(inpoly.size == sz)
+        # The backwards C has 27 points in the polygon
+        inpoly = f((polys[1],), inon, closed)
+        assert(np.count_nonzero(inpoly) == 27)
+        assert(inpoly.size == sz)
+        # The combined "doughnut" has 35 (removed double counting!)
+        inpoly = f(polys[:2], inon, closed)
+        assert(np.count_nonzero(inpoly) == 35)
+        assert(inpoly.size == sz)
+        # The square has 9 points in the polygon
+        # This is a total of 44 in and 56 out.
+        inpoly = f(polys, inon, closed)
+        assert(np.count_nonzero(inpoly) == 44)
+        assert(inpoly.size == sz)
+
+        # With inon = False:
+        inon = False
+        if _DEBUG:
+            inpoly = f(polys, inon, closed)
+            plt.figure()
+            plt.scatter(Xr[inpoly == 1], Yr[inpoly == 1], c='r', marker='x')
+            plt.hold
+            plt.scatter(Xr[inpoly == 0], Yr[inpoly == 0], c='y')
+            for p in polys:
+                plot_poly(plt, p[:, 0], p[:, 1])
+            plt.show()
+
+        # From a manual count...
+        # The quadrilateral has 19 points in the polygon
+        inpoly = f((polys[0],), inon, closed)
+        assert(np.count_nonzero(inpoly) == 19)
+        assert(inpoly.size == sz)
+        # The backwards C has 18 points in the polygon
+        inpoly = f((polys[1],), inon, closed)
+        assert(np.count_nonzero(inpoly) == 18)
+        assert(inpoly.size == sz)
+        # The combined "doughnut" has 30 (removed double counting!)
+        inpoly = f(polys[:2], inon, closed)
+        assert(np.count_nonzero(inpoly) == 30)
+        assert(inpoly.size == sz)
+        # The square has 1 points in the polygon
+        # This is a total of 31 in 69 out.
+        inpoly = f(polys, inon, closed)
+        assert(np.count_nonzero(inpoly) == 31)
+        assert(inpoly.size == sz)

--- a/earthio/filters/tests/test_sample_pipeline.py
+++ b/earthio/filters/tests/test_sample_pipeline.py
@@ -12,12 +12,10 @@ import xarray as xr
 
 from elm.config.tests.fixtures import *
 from elm.config import DEFAULTS, DEFAULT_TRAIN, ConfigParser
-import ..sample_pipeline as pipeline
-from elm.pipeline.tests.util import tmp_dirs_context
-from ..make_blobs import (random_elm_store,
-                          BANDS,
-                          GEO)
-from elm.pipeline import Pipeline
+import earthio.filters.sample_pipeline as pipeline
+from earthio.filters.make_blobs import (random_elm_store,
+                                        BANDS,
+                                        GEO)
 BASE = copy.deepcopy(DEFAULTS)
 
 
@@ -33,7 +31,7 @@ def sampler(**kwargs):
 BASE['data_sources'] ={k:  {'args_list': [()]*10,'sampler': sampler}
                        for k in DEFAULTS['data_sources']}
 
-
+@pytest.mark.skip('Depends on elm.sample_util.sample_pipeline.make_pipeline_steps and elm.pipeline.tests.util.tmp_dirs_context')
 def test_pipeline_feature_selection():
     tag = selection_name = 'variance_selection'
     config = copy.deepcopy(BASE)

--- a/earthio/filters/tests/test_sample_pipeline.py
+++ b/earthio/filters/tests/test_sample_pipeline.py
@@ -10,14 +10,11 @@ import pytest
 from sklearn.decomposition import IncrementalPCA
 import xarray as xr
 
-from elm.config.tests.fixtures import *
-from elm.config import DEFAULTS, DEFAULT_TRAIN, ConfigParser
+from earthio.filters.config.tests.fixtures import *
 import earthio.filters.sample_pipeline as pipeline
 from earthio.filters.make_blobs import (random_elm_store,
                                         BANDS,
                                         GEO)
-BASE = copy.deepcopy(DEFAULTS)
-
 
 
 def sampler(**kwargs):
@@ -28,13 +25,13 @@ def sampler(**kwargs):
     return es
 
 
-BASE['data_sources'] ={k:  {'args_list': [()]*10,'sampler': sampler}
-                       for k in DEFAULTS['data_sources']}
-
 @pytest.mark.skip('Depends on elm.sample_util.sample_pipeline.make_pipeline_steps and elm.pipeline.tests.util.tmp_dirs_context')
 def test_pipeline_feature_selection():
+    from elm.config import DEFAULTS, ConfigParser
+    config = copy.deepcopy(DEFAULTS)
+    config['data_sources'] ={k:  {'args_list': [()]*10,'sampler': sampler}
+                             for k in DEFAULTS['data_sources']}
     tag = selection_name = 'variance_selection'
-    config = copy.deepcopy(BASE)
     with tmp_dirs_context(tag) as (train_path, predict_path, cwd):
         for idx, action in enumerate(config['run']):
             if 'train' in action or 'predict' in action:

--- a/earthio/filters/tests/test_sample_pipeline.py
+++ b/earthio/filters/tests/test_sample_pipeline.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import copy
+
+from earthio import ElmStore
+from earthio.reshape import *
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.decomposition import IncrementalPCA
+import xarray as xr
+
+from elm.config.tests.fixtures import *
+from elm.config import DEFAULTS, DEFAULT_TRAIN, ConfigParser
+import ..sample_pipeline as pipeline
+from elm.pipeline.tests.util import tmp_dirs_context
+from ..make_blobs import (random_elm_store,
+                          BANDS,
+                          GEO)
+from elm.pipeline import Pipeline
+BASE = copy.deepcopy(DEFAULTS)
+
+
+
+def sampler(**kwargs):
+    es = random_elm_store(BANDS)
+    for band in BANDS[:len(BANDS) // 2]:
+        band_arr = getattr(es, band)
+        band_arr.values *= 1e-7
+    return es
+
+
+BASE['data_sources'] ={k:  {'args_list': [()]*10,'sampler': sampler}
+                       for k in DEFAULTS['data_sources']}
+
+
+def test_pipeline_feature_selection():
+    tag = selection_name = 'variance_selection'
+    config = copy.deepcopy(BASE)
+    with tmp_dirs_context(tag) as (train_path, predict_path, cwd):
+        for idx, action in enumerate(config['run']):
+            if 'train' in action or 'predict' in action:
+                train_name = action.get('train', action.get('predict'))
+                if 'pipeline' in action:
+                    if not isinstance(action['pipeline'], (list, tuple)):
+                        action['pipeline'] = config['pipelines'][action['pipeline']]
+                    action['pipeline'] += [{'feature_selection': selection_name}]
+                else:
+                    action['pipeline'] = [{'feature_selection': selection_name}]
+
+                config2 = ConfigParser(config=BASE)
+                config2.feature_selection[selection_name] = {
+                    'method': 'VarianceThreshold',
+                    'score_func': None,
+                    'threshold': 0.08,
+                }
+                X = sampler()
+                steps = pipeline.make_pipeline_steps(config2, action['pipeline'])
+                pipe = Pipeline(steps)
+                transform_models = None
+                for repeats in range(5):
+                    XX, _, _ = pipe.fit_transform(X)
+                    assert XX.flat.shape[1] < 40
+
+
+@pytest.mark.slow
+def test_elm_store_to_flat_to_elm_store():
+    attrs = {'geo_transform': (-10007554.677, 926.625433055833,
+                              0.0, 4447802.078667,
+                              0.0, -926.6254330558334)}
+    samp_np = np.random.uniform(0, 1, 20 * 50).reshape((20,50))
+    samp = ElmStore({'sample': xr.DataArray(samp_np,
+                    coords=[('y', np.arange(20)),('x', np.arange(50))],
+                    dims=['y', 'x'],
+                    attrs=attrs)}, attrs=attrs)
+    flat = flatten(samp)
+    samp2 = inverse_flatten(flat)
+    diff = samp.sample.values - samp2.sample.values
+    assert np.max(np.abs(diff)) < 1e-3
+    values = samp.sample.values.copy()
+    values[0, 0] = np.NaN
+    values[0, 3] = np.NaN
+    samp.sample.values = values
+    flat_smaller = drop_na_rows(flatten(samp))
+    assert flat_smaller.flat.values.shape[0] == np.prod(samp.sample.values.shape) - 2
+    samp2 = inverse_flatten(flat_smaller)
+    v = samp.sample.values
+    v2 = samp2.sample.values
+    assert v[np.isnan(v)].size == v2[np.isnan(v2)].size
+    v = v[~np.isnan(v)]
+    v2 = v2[~np.isnan(v2)]
+    assert np.all(v == v2)
+

--- a/earthio/filters/tests/test_transform.py
+++ b/earthio/filters/tests/test_transform.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import OrderedDict
+import copy
+import glob
+import os
+
+import pytest
+import yaml
+
+from sklearn.decomposition import IncrementalPCA
+
+from elm.config.tests.fixtures import *
+from earthio.reshape import *
+from earthio import ElmStore
+from elm.pipeline import steps
+from ..make_blobs import random_elm_store
+
+X = flatten(random_elm_store())
+
+def _run_assertions(trans, y, sample_weight):
+    assert y is None
+    assert sample_weight is None
+    assert isinstance(trans, ElmStore)
+    assert hasattr(trans, 'flat')
+    assert tuple(trans.flat.dims) == ('space', 'band')
+    assert trans.flat.values.shape[1] == 3
+    assert trans.flat.values.shape[0] == X.flat.values.shape[0]
+
+
+def test_fit_transform():
+    t = steps.Transform(IncrementalPCA(n_components=3))
+    trans, y, sample_weight = t.fit_transform(X)
+    _run_assertions(trans, y, sample_weight)
+
+reason = ('Partial fit and Pipeline will be refactored '
+          'significantly soon.  We need to make sure '
+          'partial_fit of PCA is handled and tested, '
+          'but not efficient to do so now.  A regression'
+          ' test failure arose here due to bug fixed '
+          'elsewhere for July 11 2017 NLDAS demo.')
+@pytest.mark.xfail(strict=False, reason=reason)
+def test_partial_fit_transform():
+    t = steps.Transform(IncrementalPCA(n_components=3), partial_fit_batches=3)
+    trans, y, sample_weight = t.fit_transform(X)
+    _run_assertions(trans, y, sample_weight)
+    t2 = steps.Transform(IncrementalPCA(n_components=3), partial_fit_batches=3)
+    with pytest.raises(TypeError):
+        t2.partial_fit = None # will try to call this and get TypeError
+        t2.fit_transform(X)
+
+
+def test_fit():
+    t = steps.Transform(IncrementalPCA(n_components=3), partial_fit_batches=2)
+    fitted = t.fit(X)
+    assert isinstance(fitted, steps.Transform)
+    assert isinstance(fitted._estimator, IncrementalPCA)
+    trans, y, sample_weight = fitted.transform(X)
+    _run_assertions(trans, y, sample_weight)
+

--- a/earthio/filters/tests/test_transform.py
+++ b/earthio/filters/tests/test_transform.py
@@ -10,7 +10,7 @@ import yaml
 
 from sklearn.decomposition import IncrementalPCA
 
-from elm.config.tests.fixtures import *
+from earthio.filters.config.tests.fixtures import *
 from earthio.reshape import *
 from earthio import ElmStore
 from earthio.filters.make_blobs import random_elm_store

--- a/earthio/filters/tests/test_transform.py
+++ b/earthio/filters/tests/test_transform.py
@@ -13,8 +13,7 @@ from sklearn.decomposition import IncrementalPCA
 from elm.config.tests.fixtures import *
 from earthio.reshape import *
 from earthio import ElmStore
-from elm.pipeline import steps
-from ..make_blobs import random_elm_store
+from earthio.filters.make_blobs import random_elm_store
 
 X = flatten(random_elm_store())
 
@@ -28,6 +27,7 @@ def _run_assertions(trans, y, sample_weight):
     assert trans.flat.values.shape[0] == X.flat.values.shape[0]
 
 
+@pytest.mark.skip('Depends on elm.pipeline.steps')
 def test_fit_transform():
     t = steps.Transform(IncrementalPCA(n_components=3))
     trans, y, sample_weight = t.fit_transform(X)
@@ -39,6 +39,7 @@ reason = ('Partial fit and Pipeline will be refactored '
           'but not efficient to do so now.  A regression'
           ' test failure arose here due to bug fixed '
           'elsewhere for July 11 2017 NLDAS demo.')
+@pytest.mark.skip('Depends on elm.pipeline.steps')
 @pytest.mark.xfail(strict=False, reason=reason)
 def test_partial_fit_transform():
     t = steps.Transform(IncrementalPCA(n_components=3), partial_fit_batches=3)
@@ -50,6 +51,7 @@ def test_partial_fit_transform():
         t2.fit_transform(X)
 
 
+@pytest.mark.skip('Depends on elm.pipeline.steps')
 def test_fit():
     t = steps.Transform(IncrementalPCA(n_components=3), partial_fit_batches=2)
     fitted = t.fit(X)

--- a/earthio/filters/tests/test_ts_grid_tools.py
+++ b/earthio/filters/tests/test_ts_grid_tools.py
@@ -5,7 +5,7 @@ import pytest
 import xarray as xr
 
 from earthio import ElmStore
-from elm.config.tests.fixtures import *
+from earthio.filters.config.tests.fixtures import *
 
 def make_3d():
     arr = np.random.uniform(0, 1, 100000).reshape(100, 10, 100)

--- a/earthio/filters/tests/test_ts_grid_tools.py
+++ b/earthio/filters/tests/test_ts_grid_tools.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from earthio import ElmStore
+from elm.config.tests.fixtures import *
+from elm.pipeline import steps
+
+def make_3d():
+    arr = np.random.uniform(0, 1, 100000).reshape(100, 10, 100)
+    return ElmStore({'band_1': xr.DataArray(arr,
+                            coords=[('time', np.arange(100)),
+                                    ('x', np.arange(10)),
+                                    ('y',np.arange(100))],
+                            dims=('time', 'x', 'y'),
+                            attrs={})}, attrs={}, add_canvas=False)
+
+
+def test_ts_probs():
+
+    s = steps.TSProbs()
+    s.set_params(band='band_1', bin_size=0.5, num_bins=152, log_probs=True)
+    orig = make_3d()
+    X, _, _ = s.fit_transform(orig)
+    assert hasattr(X, 'flat')
+    assert X.flat.values.shape[1] == 152
+    s.set_params(band='band_1', bin_size=0.5, num_bins=152,
+                 log_probs=False)
+    X2, _, _ = s.fit_transform(orig)
+    assert hasattr(X2, 'flat')
+    assert X2.flat.values.shape[1] == 152
+    s.set_params(band='band_1', bin_size=0.5, num_bins=152, log_probs=True)
+    X3, _, _ = s.fit_transform(orig)
+    assert hasattr(X3, 'flat')
+    assert X3.flat.values.shape[1] == 152
+    with pytest.raises(ValueError):
+        s = steps.TSProbs()
+        s.fit_transform(orig)
+    s.set_params(band='band_1', num_bins=152, log_probs=False)
+    X4, _, _ = s.fit_transform(orig)
+    assert hasattr(X4, 'flat')
+    assert X4.flat.values.shape[1] == 152
+
+
+def test_ts_describe():
+
+    s = steps.TSDescribe()
+    s.set_params(band='band_1', axis=0)
+    orig = make_3d()
+    X, _, _ = s.fit_transform(orig)
+    bands = tuple(X.band)
+    assert bands == ('var', 'skew', 'kurt', 'min', 'max', 'median', 'std', 'np_skew')
+

--- a/earthio/filters/tests/test_ts_grid_tools.py
+++ b/earthio/filters/tests/test_ts_grid_tools.py
@@ -6,7 +6,6 @@ import xarray as xr
 
 from earthio import ElmStore
 from elm.config.tests.fixtures import *
-from elm.pipeline import steps
 
 def make_3d():
     arr = np.random.uniform(0, 1, 100000).reshape(100, 10, 100)
@@ -18,8 +17,8 @@ def make_3d():
                             attrs={})}, attrs={}, add_canvas=False)
 
 
+@pytest.mark.skip('Depends on elm.pipeline.steps')
 def test_ts_probs():
-
     s = steps.TSProbs()
     s.set_params(band='band_1', bin_size=0.5, num_bins=152, log_probs=True)
     orig = make_3d()
@@ -44,8 +43,8 @@ def test_ts_probs():
     assert X4.flat.values.shape[1] == 152
 
 
+@pytest.mark.skip('Depends on elm.pipeline.steps')
 def test_ts_describe():
-
     s = steps.TSDescribe()
     s.set_params(band='band_1', axis=0)
     orig = make_3d()

--- a/earthio/filters/transform.py
+++ b/earthio/filters/transform.py
@@ -10,11 +10,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import logging
 
-from .. import ElmStore
+from earthio import ElmStore
 import numpy as np
 import xarray as xr
 
-from .step_mixin import StepMixin
+from earthio.filters.step_mixin import StepMixin
 
 logger = logging.getLogger(__name__)
 

--- a/earthio/filters/transform.py
+++ b/earthio/filters/transform.py
@@ -1,0 +1,109 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+---------------------------------
+
+``earthio.filters.transform``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+import copy
+import logging
+
+from .. import ElmStore
+import numpy as np
+import xarray as xr
+
+from .step_mixin import StepMixin
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['Transform',]
+
+
+
+class Transform(StepMixin):
+    '''Wraps transform models like IncrementalPCA for use in elm.pipeline.Pipeline'''
+    def __init__(self, estimator, partial_fit_batches=None):
+        '''Wraps transform models like IncrementalPCA for use in elm.pipeline.Pipeline
+
+           Parameters:
+                :estimator: such as sklearn.decomposition.IncrementalPCA, a model with fit and transform methods
+                :partial_fit_batches: how many times to call partial_fit  each time Pipeline is evaluated
+
+        '''
+
+        self._estimator = estimator
+        self._partial_fit_batches = partial_fit_batches
+        self._params = estimator.get_params()
+
+    def set_params(self, **params):
+        filtered = {k: v for k, v in params.items()
+                    if k != 'partial_fit_batches'}
+        self._estimator.set_params(**filtered)
+        self._params.update(params)
+        p = params.get('partial_fit_batches')
+        if p:
+            self._partial_fit_batches = p
+
+    def get_params(self, **kwargs):
+        params = self._estimator.get_params(**kwargs)
+        params['partial_fit_batches'] = self._partial_fit_batches
+        return params
+
+    def _fit_trans(self, method, X, y=None, sample_weight=None, **kwargs):
+        fitter_func = getattr(self._estimator, method)
+        kw = dict(y=y, sample_weight=sample_weight, **kwargs)
+        kw = {k: v for k, v in kw.items() if k in self._params}
+        if isinstance(X, (ElmStore, xr.Dataset)):
+            if hasattr(X, 'flat'):
+                XX = X.flat.values
+                space = X.flat.space
+            else:
+                raise ValueError("Call elm.pipeline.steps.Flatten() before Transform in pipeline or otherwise use X as an (earthio.ElmStore or xarray.Dataset)")
+        else:
+            raise ValueError('Expected X to be an xarray.Dataset or earthio.ElmStore')
+        out = fitter_func(X.flat.values, **kw)
+        if 'transform' in method:
+            # 'transform' or 'fit_transform' was called
+            out = np.atleast_2d(out)
+            band = ['transform_{}'.format(idx)
+                    for idx in range(out.shape[1])]
+            coords = [('space', space),
+                      ('band', band)]
+            attrs = copy.deepcopy(X.attrs)
+            attrs.update(X.flat.attrs)
+            attrs['band_order'] = band
+            Xnew = ElmStore({'flat': xr.DataArray(out,
+                            coords=coords,
+                            dims=X.flat.dims,
+                            attrs=attrs)},
+                        attrs=attrs)
+            return (Xnew, y, sample_weight)
+        return out # a fitted "self"
+
+    def partial_fit_batches(self, X, y=None, sample_weight=None, **kwargs):
+        for _ in range(self._partial_fit_batches):
+            logger.debug('Transform partial fit batch {} of {}'.format(_ + 1, self._partial_fit_batches))
+            self.partial_fit(X, y=y, sample_weight=sample_weight, **kwargs)
+        return self
+
+    def partial_fit(self, X, y=None, sample_weight=None, **kwargs):
+        if not hasattr(self._estimator, 'partial_fit'):
+            raise ValueError('Cannot give partial_fit_batches to {} (does not have "partial_fit" method)'.format(self._estimator))
+        return self._fit_trans('partial_fit', X, y=y, sample_weight=sample_weight, **kwargs)
+
+    def fit(self, X, y=None, sample_weight=None, **kwargs):
+        if self._partial_fit_batches:
+            return self.partial_fit_batches(X, y=y, sample_weight=sample_weight, **kwargs)
+        return self._fit_trans('fit', X, y=y, sample_weight=sample_weight, **kwargs)
+
+    def transform(self, X, y=None, sample_weight=None, **kwargs):
+        return self._fit_trans('transform', X, y=y, sample_weight=sample_weight, **kwargs)
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+
+        if hasattr(self._estimator, 'fit_transform'):
+            return self._fit_trans('fit_transform', X, y=y, sample_weight=sample_weight, **kwargs)
+        fitted = self.fit(X, y=y, sample_weight=sample_weight, **kwargs)
+        return self.transform(X, y=y, sample_weight=sample_weight, **kwargs)

--- a/earthio/filters/ts_grid_tools.py
+++ b/earthio/filters/ts_grid_tools.py
@@ -201,7 +201,11 @@ class TSDescribe(StepMixin):
 
     def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
         __doc__ = ts_describe.__doc__
-        from elm.pipeline.steps import ModifySample
+        try:
+            from elm.pipeline.steps import ModifySample
+        except ImportError:
+            logger.error('TSDescribe.fit_transform method depends on elm.pipeline.steps.ModifySample')
+            sys.exit(1)
         if not self._kwargs.get('band'):
             raise ValueError("Expected 'band' keyword to TSProbs")
         m = ModifySample(ts_describe, **self._kwargs)

--- a/earthio/filters/ts_grid_tools.py
+++ b/earthio/filters/ts_grid_tools.py
@@ -22,8 +22,8 @@ import pandas as pd
 from scipy.stats import describe
 import xarray as xr
 
-from .step_mixin import StepMixin
-from .. import ElmStore
+from earthio.filters.step_mixin import StepMixin
+from earthio import ElmStore
 
 
 logger = logging.getLogger(__name__)
@@ -174,7 +174,11 @@ class TSProbs(StepMixin):
 
     def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
         __doc__ = ts_probs.__doc__
-        from elm.pipeline.steps import ModifySample
+        try:
+            from elm.pipeline.steps import ModifySample
+        except ImportError:
+            logger.error('TSProbs.fit_transform method depends on elm.pipeline.steps.ModifySample')
+            sys.exit(1)
         if not self._kwargs.get('band'):
             raise ValueError("Expected 'band' keyword to TSProbs")
         m = ModifySample(ts_probs, **self._kwargs)

--- a/earthio/filters/ts_grid_tools.py
+++ b/earthio/filters/ts_grid_tools.py
@@ -1,0 +1,216 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+'''
+---------------------------------
+
+``earthio.filters.ts_grig_tools``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+'''
+import calendar
+from collections import OrderedDict
+import copy
+import gc
+from itertools import product, combinations
+import logging
+import glob
+import random
+
+from sklearn.cluster import MiniBatchKMeans
+import numpy as np
+import pandas as pd
+from scipy.stats import describe
+import xarray as xr
+
+from .step_mixin import StepMixin
+from .. import ElmStore
+
+
+logger = logging.getLogger(__name__)
+slc = slice(None)
+
+def _ij_for_axis(axis, i, j):
+    if axis == 0:
+        return (slc, i, j)
+    elif axis == 1:
+        return (i, slc, j)
+    elif axis == 2:
+        return (i, j, slc)
+    else:
+        raise ValueError("Expected axis in (0, 1, 2)")
+
+
+def ts_describe(X, y=None, sample_weight=None, **kwargs):
+    '''scipy.describe on the `band` from kwargs
+    that is a 3-D DataArray in X
+
+    Parameters:
+        X:  ElmStore or xarray.Dataset
+        y:  passed through
+        sample_weight: passed through
+        kwargs: Keywords:
+            axis: Integer like 0, 1, 2 to indicate which is the time axis of cube
+            band: The name of the DataArray in ElmStore to run scipy.describe on
+    Returns:
+        X:  ElmStore with DataArray class "flat"
+    '''
+    band = kwargs['band']
+    logger.debug('Start scipy_describe band: {}'.format(band))
+    band_arr = getattr(X, band)
+    cols = ('var', 'skew', 'kurt', 'min', 'max', 'median', 'std', 'np_skew')
+    num_cols = len(cols)
+
+    inds = _ij_for_axis(kwargs['axis'], 0, 0)
+    shp = tuple(s for idx, s in enumerate(band_arr.values.shape)
+                if isinstance(inds[idx], int))
+    num_rows = np.prod(shp)
+    new_arr = np.empty((num_rows, num_cols))
+    for row, (i, j) in enumerate(product(*(range(s) for s in shp))):
+        ind1, ind2, ind3 = _ij_for_axis(kwargs['axis'], i, j)
+        values = band_arr.values[ind1, ind2, ind3]
+        d = describe(values)
+        t = (d.variance, d.skewness, d.kurtosis, d.minmax[0], d.minmax[1])
+        median = np.median(values)
+        std = np.std(values)
+        non_param_skew = (d.mean - median) / std
+        r = t + (median, std, non_param_skew)
+        new_arr[row, :] = r
+    attrs = copy.deepcopy(X.attrs)
+    attrs.update(kwargs)
+    da = xr.DataArray(new_arr,
+                      coords=[('space', np.arange(num_rows)),
+                              ('band', np.array(cols))],
+                      dims=('space', 'band'),
+                      attrs=attrs)
+    X_new = ElmStore({'flat': da}, attrs=attrs, add_canvas=False)
+    return (X_new, y, sample_weight)
+
+
+def ts_probs(X, y=None, sample_weight=None, **kwargs):
+    '''Fixed or unevenly spaced histogram binning for
+    the time dimension of a 3-D cube DataArray in X
+
+    Parameters:
+        X: ElmStore or xarray.Dataset
+        y: passed through
+        sample_weight: passed through
+        kwargs: Keywords:
+            axis: Integer like 0, 1, 2 to indicate which is the time axis of cube
+            band: The name of DataArray to time series bin (required)
+            bin_size: Size of the fixed bin or None to use np.histogram (irregular bins)
+            num_bins: How many bins
+            log_probs: Return probabilities associated with log counts? True / False
+    Returns:
+        X: ElmStore with DataArray called flat that has columns composed of:
+            * log transformed counts (if kwargs["log_probs"]) or
+            * counts (if kwargs["counts"])
+
+        Number of columns will be equal to num_bins
+    '''
+    band = kwargs['band']
+    band_arr = getattr(X, band)
+    num_bins = kwargs['num_bins']
+    bin_size = kwargs.get('bin_size', None)
+    log_probs = kwargs.get('log_probs', None)
+    if bin_size is not None:
+        bins = np.linspace(-bin_size * num_bins // 2, bin_size * num_bins // 2, num_bins)
+    num_rows = np.prod(band_arr.shape[1:])
+    col_count =  num_bins
+    new_arr = np.empty((num_rows, col_count),dtype=np.float64)
+    logger.info("Histogramming...")
+    small = 1e-8
+    inds = _ij_for_axis(kwargs['axis'], 0, 0)
+    shp = tuple(s for idx, s in enumerate(band_arr.values.shape)
+                if isinstance(inds[idx], int))
+    for row, (i, j) in enumerate(product(*(range(s) for s in shp))):
+        ind1, ind2, ind3 = _ij_for_axis(kwargs['axis'], i, j)
+        values_slc = band_arr.values[ind1, ind2, ind3]
+        if bin_size is not None:
+            indices = np.searchsorted(bins, values_slc, side='left')
+            binned = np.bincount(indices).astype(np.float64)
+            # add small to avoid log zero
+            if log_probs:
+                was_zero = binned[binned == 0].size
+                binned[binned == 0] = small
+            else:
+                extra = 0.
+            binned /= binned.sum()
+            if log_probs:
+                binned = np.log10(binned)
+            new_arr[row, :binned.size] = binned
+            if binned.size < new_arr.shape[1]:
+                new_arr[row, binned.size:] = 0
+        else:
+            hist, edges = np.histogram(values_slc, num_bins)
+            # add one observation to avoid log zero
+            if log_probs:
+                was_zero = hist[hist == 0].size
+                hist[hist == 0] = small
+            else:
+                extra = 1.0
+            hist = hist.sum()
+            if log_probs:
+                hist = np.log10(hist)
+            new_arr[row, :] = hist
+
+    gc.collect()
+    attrs = copy.deepcopy(X.attrs)
+    attrs.update(kwargs)
+    da = xr.DataArray(new_arr,
+                      coords=[('space', np.arange(num_rows)),
+                              ('band', np.arange(col_count))],
+                      dims=('space', 'band'),
+                      attrs=attrs)
+    X_new = ElmStore({'flat': da}, attrs=attrs, add_canvas=False)
+    return (X_new, y, sample_weight)
+
+
+class TSProbs(StepMixin):
+    def __init__(self, axis=0, band=None, bin_size=None,
+                 num_bins=None, log_probs=True):
+        __doc__ = ts_probs.__doc__
+        self._kwargs = dict(axis=axis, band=band, bin_size=bin_size,
+                            num_bins=num_bins, log_probs=log_probs)
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        __doc__ = ts_probs.__doc__
+        from elm.pipeline.steps import ModifySample
+        if not self._kwargs.get('band'):
+            raise ValueError("Expected 'band' keyword to TSProbs")
+        m = ModifySample(ts_probs, **self._kwargs)
+        return (m.fit_transform(X)[0], y, sample_weight)
+
+    transform = fit = fit_transform
+
+    def get_params(self):
+        return self._kwargs.copy()
+
+    def set_params(self, **params):
+        for k, v in params.items():
+            self._kwargs[k] = v
+
+class TSDescribe(StepMixin):
+
+    def __init__(self, axis=0, band=None):
+        __doc__ = ts_describe.__doc__
+        self._kwargs = dict(axis=axis, band=band)
+
+    def fit_transform(self, X, y=None, sample_weight=None, **kwargs):
+        __doc__ = ts_describe.__doc__
+        from elm.pipeline.steps import ModifySample
+        if not self._kwargs.get('band'):
+            raise ValueError("Expected 'band' keyword to TSProbs")
+        m = ModifySample(ts_describe, **self._kwargs)
+        X_new = m.fit_transform(X)[0]
+        return (X_new, y, sample_weight)
+
+    transform = fit = fit_transform
+
+    def get_params(self):
+        return self._kwargs.copy()
+
+    def set_params(self, **params):
+        for k, v in params.items():
+            self._kwargs[k] = v
+
+__all__ = ['TSDescribe', 'TSProbs']

--- a/environment.yml
+++ b/environment.yml
@@ -1,17 +1,16 @@
 name: earth-env
-
 channels:
+  - gbrener
   - ioam
   - conda-forge
   - scitools/label/dev
-  - elm
-
 dependencies:
   - deap
   - dill
   - gdal
   - iris
   - pytables
+  - pytest
   - python-magic
   - rasterio
   - scikit-image
@@ -22,6 +21,5 @@ dependencies:
   - geoviews
   - paramnb
   - jupyter
-  - elm # only for unit-testing
   - pip:
     - cachey

--- a/environment.yml
+++ b/environment.yml
@@ -25,4 +25,3 @@ dependencies:
   - elm # only for unit-testing
   - pip:
     - cachey
-

--- a/environment.yml
+++ b/environment.yml
@@ -4,39 +4,25 @@ channels:
   - ioam
   - conda-forge
   - scitools/label/dev
+  - elm
 
 dependencies:
-  - attrs
-  - bokeh
-  - cartopy
-  - colorcet
-  - dask
-  - datashader
+  - deap
   - dill
-  - distributed
-  - geoviews
-  - holoviews
+  - gdal
   - iris
-  - jupyter
-  - krb5
-  - matplotlib
-  - networkx
-  - numba
-  - numpy
-  - pandas
-  - paramnb
-  - pyproj
   - pytables
-  - pytest
-  - python=3.5
+  - python-magic
   - rasterio
-  - requests
-  - scipy
-  - shapely
+  - scikit-image
+  - scikit-learn
   - statsmodels
-  - tblib
-  - xarray
-  - yaml
-  - six
+  - colorcet
+  - datashader
+  - geoviews
+  - paramnb
+  - jupyter
+  - elm # only for unit-testing
   - pip:
-      - cachey
+    - cachey
+


### PR DESCRIPTION
As the first part of https://github.com/ContinuumIO/elm/issues/149, this PR moves the `elm.sample_util` package to `earthio.filters`. It also removes all of `earthio`'s dependencies on `elm`, with the exception of in ts_grid_tools (https://github.com/ContinuumIO/earthio/blob/sample_util_to_filters/earthio/filters/ts_grid_tools.py#L180 and https://github.com/ContinuumIO/earthio/blob/sample_util_to_filters/earthio/filters/ts_grid_tools.py#L205), where the import causes an exception to get raised if `elm` is not installed.

It's a work-in-progress until the tests pass; Python 3.6 passes but 3.5 and 2.7 do not due to a gdal installation issue (referred to by https://github.com/conda-forge/gdal-feedstock/issues/170).