### PR TITLE
Pin gdal version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 
 dist: trusty
 
-branches:
-  only:
-    - master
-
 env:
   global:
     - EARTHIO_TEST_ENV=earth-test-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ notifications:
 deploy:
   - provider: script
     script:
-      - conda install --name root anaconda-client && conda build $EARTHIO_CHANNEL_STR --output --python $PYTHON --numpy $NUMPY conda.recipe | xargs conda convert -p all -o _pkgs && find _pkgs -type f -name "*.tar.bz2" -exec anaconda -t $ANACONDA_UPLOAD_TOKEN upload --user $ANACONDA_UPLOAD_USER --label dev {} \+
+      - conda install --name root anaconda-client && conda build $EARTHIO_CHANNEL_STR --output --python $PYTHON --numpy $NUMPY conda.recipe | xargs conda convert -p all -o _pkgs && find _pkgs -type f -name "*.tar.bz2" -exec anaconda -t $ANACONDA_UPLOAD_TOKEN upload --user $ANACONDA_UPLOAD_USER --label dev --force {} \+
     on:
       tags: false
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 
 dist: trusty
 
+branches:
+  only:
+    - master
+
 env:
   global:
     - EARTHIO_TEST_ENV=earth-test-env

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
     - deap
     - dill
-    - gdal
+    - gdal ==2.1.*
     - iris
     - pytables
     - python-magic


### PR DESCRIPTION
The GDAL version needs to get pinned due to an outstanding issue with how conda interacts with the gdal-feedstock on conda-forge, causing CI build error in https://github.com/ContinuumIO/elm/pull/187.

The issue is marked as "closed" after the above workaround was proposed: https://github.com/conda-forge/gdal-feedstock/issues/170