### PR TITLE
Restore previous environment.yml

### DIFF
--- a/build_earthio_env.sh
+++ b/build_earthio_env.sh
@@ -27,6 +27,7 @@ else
 fi
 
 if [ -z "$IGNORE_ELM_DATA_DOWNLOAD" ]; then
+    conda install -c conda-forge 'gdal=2.1.*'
     mkdir -p $ELM_EXAMPLE_DATA_PATH
     pushd $ELM_EXAMPLE_DATA_PATH && python "$EARTHIO_BUILD_DIR/scripts/download_test_data.py" --files hdf4.tar.bz2 tif.tar.bz2 && popd
 fi

--- a/build_earthio_env.sh
+++ b/build_earthio_env.sh
@@ -27,7 +27,6 @@ else
 fi
 
 if [ -z "$IGNORE_ELM_DATA_DOWNLOAD" ]; then
-    conda install -c defaults -c conda-forge requests pbzip2 python-magic
     mkdir -p $ELM_EXAMPLE_DATA_PATH
     pushd $ELM_EXAMPLE_DATA_PATH && python "$EARTHIO_BUILD_DIR/scripts/download_test_data.py" --files hdf4.tar.bz2 tif.tar.bz2 && popd
 fi

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,53 +1,41 @@
-package:
-  name: earthio
-  version: {{ environ.get('GIT_DESCRIBE_TAG', 'notag') }}
-
-source:
-  path: ..
-
-build:
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)|int }}
-
-requirements:
-  build:
-    - python
-    - setuptools
-
-  run:
-    - deap
-    - dill
-    - iris
-    - pytables
-    - python-magic
-    - rasterio
-    - scikit-image
-    - scikit-learn
-    - statsmodels
-    - colorcet
-    - datashader
-    - geoviews
-    - paramnb
-    - jupyter
-
-about:
-  home: http://github.com/ContinuumIO/elm
-  license: MIT
-
-extra:
-  channels:
-    - defaults
-    - gbrener
-    - ioam
-    - conda-forge
-    - scitools/label/dev
-
-  maintainers:
-    - Peter Steinberg - Continuum Analytics - psteinberg [at] continuum [dot] io
-    - Greg Brener - Continuum Analytics - gbrener [at] continuum [dot] io
-
-test:
-  imports:
-    - earthio
-
-  requires:
-    - pytest
+name: earth-env
+channels:
+  - gbrener
+  - ioam
+  - conda-forge
+  - scitools/label/dev
+dependencies:
+  - attrs
+  - bokeh
+  - cartopy
+  - colorcet
+  - dask
+  - datashader
+  - dill
+  - distributed
+  - geoviews
+  - holoviews
+  - iris
+  - jupyter
+  - krb5
+  - matplotlib
+  - networkx
+  - numba
+  - numpy
+  - pandas
+  - paramnb
+  - pyproj
+  - pytables
+  - pytest
+  - python=3.5
+  - rasterio
+  - requests
+  - scipy
+  - shapely
+  - statsmodels
+  - tblib
+  - xarray
+  - yaml
+  - six
+  - pip:
+      - cachey

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - datashader
     - dill
     - distributed
-    - gdal==2.1.*
     - geoviews
     - holoviews
     - iris

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - datashader
     - dill
     - distributed
+    - gdal==2.1.*
     - geoviews
     - holoviews
     - iris

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,41 +1,70 @@
-name: earth-env
-channels:
-  - gbrener
-  - ioam
-  - conda-forge
-  - scitools/label/dev
-dependencies:
-  - attrs
-  - bokeh
-  - cartopy
-  - colorcet
-  - dask
-  - datashader
-  - dill
-  - distributed
-  - geoviews
-  - holoviews
-  - iris
-  - jupyter
-  - krb5
-  - matplotlib
-  - networkx
-  - numba
-  - numpy
-  - pandas
-  - paramnb
-  - pyproj
-  - pytables
-  - pytest
-  - python=3.5
-  - rasterio
-  - requests
-  - scipy
-  - shapely
-  - statsmodels
-  - tblib
-  - xarray
-  - yaml
-  - six
-  - pip:
-      - cachey
+package:
+  name: earthio
+  version: {{ environ.get('GIT_DESCRIBE_TAG', 'notag') }}
+
+source:
+  path: ..
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)|int }}
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - attrs
+    - bokeh
+    - cartopy
+    - colorcet
+    - dask
+    - datashader
+    - dill
+    - distributed
+    - geoviews
+    - holoviews
+    - iris
+    - jupyter
+    - krb5
+    - matplotlib
+    - networkx
+    - numba
+    - numpy
+    - pandas
+    - paramnb
+    - pyproj
+    - pytables
+    - python
+    - rasterio
+    - requests
+    - scipy
+    - shapely
+    - statsmodels
+    - tblib
+    - xarray
+    - yaml
+    - six
+
+about:
+  home: http://github.com/ContinuumIO/elm
+  license: MIT
+
+extra:
+  channels:
+    - defaults
+    - gbrener
+    - ioam
+    - conda-forge
+    - scitools/label/dev
+
+  maintainers:
+    - Peter Steinberg - Continuum Analytics - psteinberg [at] continuum [dot] io
+    - Greg Brener - Continuum Analytics - gbrener [at] continuum [dot] io
+
+test:
+  imports:
+    - earthio
+
+  requires:
+    - pytest

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,6 @@ requirements:
   run:
     - deap
     - dill
-    - gdal ==2.1.*
     - iris
     - pytables
     - python-magic

--- a/earthio/filters/band_selection.py
+++ b/earthio/filters/band_selection.py
@@ -9,8 +9,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 '''
 from collections import OrderedDict
 
-from gdalconst import GA_ReadOnly
-import gdal
 import logging
 
 from earthio.filters.config.func_signatures import get_args_kwargs_defaults

--- a/earthio/hdf4.py
+++ b/earthio/hdf4.py
@@ -18,8 +18,6 @@ import copy
 import gc
 import logging
 
-import gdal
-from gdalconst import GA_ReadOnly
 import numpy as np
 import xarray as xr
 
@@ -43,6 +41,8 @@ logger = logging.getLogger(__name__)
 
 def load_hdf4_meta(datafile):
     '''Load meta and band_meta for a datafile'''
+    import gdal
+    from gdalconst import GA_ReadOnly
     f = gdal.Open(datafile, GA_ReadOnly)
     sds = f.GetSubDatasets()
 
@@ -74,6 +74,8 @@ def load_hdf4_array(datafile, meta, band_specs=None):
     Returns:
         :Elmstore: Elmstore of teh hdf4 data
     '''
+    import gdal
+    from gdalconst import GA_ReadOnly
     from earthio import ElmStore
     from earthio.metadata_selection import match_meta
     logger.debug('load_hdf4_array: {}'.format(datafile))

--- a/earthio/hdf5.py
+++ b/earthio/hdf5.py
@@ -18,8 +18,6 @@ import copy
 import gc
 import logging
 
-import gdal
-from gdalconst import GA_ReadOnly
 import numpy as np
 import xarray as xr
 
@@ -52,6 +50,9 @@ def _nc_str_to_dict(nc_str):
 
 def load_hdf5_meta(datafile):
     '''Load dataset and subdataset metadata from HDF5 file'''
+    import gdal
+    from gdalconst import GA_ReadOnly
+
     f = gdal.Open(datafile, GA_ReadOnly)
     sds = f.GetSubDatasets()
     band_metas = []
@@ -76,6 +77,7 @@ def load_hdf5_meta(datafile):
 
 def load_subdataset(subdataset, attrs, band_spec, **reader_kwargs):
     '''Load a single subdataset'''
+    import gdal
     data_file = gdal.Open(subdataset)
     raster = raster_as_2d(data_file.ReadAsArray(**reader_kwargs))
     #raster = raster.T
@@ -126,6 +128,8 @@ def load_hdf5_array(datafile, meta, band_specs):
     Returns:
         :es: An ElmStore
     '''
+    import gdal
+    from gdalconst import GA_ReadOnly
 
     logger.debug('load_hdf5_array: {}'.format(datafile))
     f = gdal.Open(datafile, GA_ReadOnly)

--- a/earthio/metadata_selection.py
+++ b/earthio/metadata_selection.py
@@ -10,8 +10,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import OrderedDict
 
-from gdalconst import GA_ReadOnly
-import gdal
 import logging
 import pandas as pd
 import re

--- a/earthio/tests/test_hdf5.py
+++ b/earthio/tests/test_hdf5.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import glob
-import gdal
 import os
 
 import attr
@@ -55,6 +54,7 @@ def test_read_meta(hdf):
 @pytest.mark.skipif(not HDF5_FILES,
                    reason='elm-data repo has not been cloned')
 def test_load_subdataset():
+    import gdal
     f = HDF5_FILES[0]
     _ , band_specs = get_band_specs(f)
     data_file = gdal.Open(f)

--- a/earthio/util.py
+++ b/earthio/util.py
@@ -13,9 +13,7 @@ import logging
 import numbers
 import re
 
-import gdal
 import numpy as np
-import ogr
 from rasterio.coords import BoundingBox
 import scipy.interpolate as spi
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - datashader
   - dill
   - distributed
+  - gdal=2.1.*
   - geoviews
   - holoviews
   - iris
@@ -24,12 +25,15 @@ dependencies:
   - numpy
   - pandas
   - paramnb
+  - pbzip2  # elm-data
   - pyproj
   - pytables
   - pytest
   - python=3.5
+  - python-magic  # elm-data
   - rasterio
   - requests
+  - scikit-learn
   - scipy
   - shapely
   - statsmodels

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
   - datashader
   - dill
   - distributed
-  - gdal=2.1.*
   - geoviews
   - holoviews
   - iris

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ channels:
 dependencies:
   - deap
   - dill
-  - gdal =2.1.*
   - iris
   - pytables
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -5,20 +5,37 @@ channels:
   - conda-forge
   - scitools/label/dev
 dependencies:
-  - deap
+  - attrs
+  - bokeh
+  - cartopy
+  - colorcet
+  - dask
+  - datashader
   - dill
+  - distributed
+  - geoviews
+  - holoviews
   - iris
+  - jupyter
+  - krb5
+  - matplotlib
+  - networkx
+  - numba
+  - numpy
+  - pandas
+  - paramnb
+  - pyproj
   - pytables
   - pytest
-  - python-magic
+  - python=3.5
   - rasterio
-  - scikit-image
-  - scikit-learn
+  - requests
+  - scipy
+  - shapely
   - statsmodels
-  - colorcet
-  - datashader
-  - geoviews
-  - paramnb
-  - jupyter
+  - tblib
+  - xarray
+  - yaml
+  - six
   - pip:
-    - cachey
+      - cachey

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(name='earthio',
       description='Readers',
       include_package_data=True,
       install_requires=[],
-      packages=['earthio'],
+      packages=['earthio', 'earthio.filters'],
       package_data={},
       entry_points={})


### PR DESCRIPTION
This PR restores the pre-existing environment.yml file, since there are too many issues with `gdal` installation since attempting to condense it.