### PR TITLE
fix some channels in environment.yml, add paramnb

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -31,7 +31,6 @@ requirements:
     - numba
     - numpy
     - pandas
-    - paramnb
     - pyproj
     - pytables
     - python

--- a/environment.yml
+++ b/environment.yml
@@ -7,16 +7,15 @@ channels:
   - elm/label/dev
 
 dependencies:
-  - attrs
-  - bokeh
-  - cartopy
+  - conda-forge::bokeh
+  - anaconda::cartopy
   - colorcet
   - dask
   - datashader
   - dill
   - distributed
-  - geoviews
-  - holoviews
+  - conda-forge::geoviews
+  - conda-forge::holoviews
   - iris
   - jupyter
   - krb5
@@ -25,14 +24,15 @@ dependencies:
   - numba
   - numpy
   - pandas
-  - paramnb
   - pbzip2  # elm-data
+  - conda-forge::pydap
+  - conda-forge::pynio
   - pyproj
   - pytables
   - pytest
-  - python=3.5
+  - python=2.7
   - python-magic  # elm-data
-  - rasterio
+  - anaconda::rasterio
   - requests
   - scikit-learn
   - scipy


### PR DESCRIPTION
* Adds paramnb to conda package
* Fixes some channels in environment.yml

Currently this is hardwired to Python 2.7 due its use in NLDAS related stuff with Grib files (encountering pynio issues over last month in Python 3).  Probably will change that - just wanted to push this up now.